### PR TITLE
fix: prevented to extend lifetime of references to Cmd's attributes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,6 @@ categories = ["command-line interface"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+
+[dev-dependencies]
+trybuild = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,11 +147,11 @@ impl<'a> Cmd<'a> {
         }
     }
 
-    pub fn name(&self) -> &'a str {
+    pub fn name(&'a self) -> &'a str {
         self.name
     }
 
-    pub fn args(&self) -> &[&'a str] {
+    pub fn args(&'a self) -> &'a [&'a str] {
         &self.args
     }
 
@@ -159,7 +159,7 @@ impl<'a> Cmd<'a> {
         self.opts.contains_key(name)
     }
 
-    pub fn opt_arg(&self, name: &str) -> Option<&str> {
+    pub fn opt_arg(&'a self, name: &str) -> Option<&'a str> {
         if let Some(opt_vec) = self.opts.get(name) {
             if opt_vec.len() > 0 {
                 return Some(opt_vec[0]);
@@ -168,7 +168,7 @@ impl<'a> Cmd<'a> {
         None
     }
 
-    pub fn opt_args(&self, name: &str) -> Option<&[&'a str]> {
+    pub fn opt_args(&'a self, name: &str) -> Option<&'a [&'a str]> {
         match self.opts.get(name) {
             Some(vec) => Some(&vec),
             None => None,

--- a/tests/compile_errors/lifetime_of_cmd_args.rs
+++ b/tests/compile_errors/lifetime_of_cmd_args.rs
@@ -1,0 +1,18 @@
+use cliargs::Cmd;
+
+fn main() {
+    fn returns_one_of_cmd_args() -> &'static str {
+        let mut cmd = cliargs::Cmd::with_strings(["/path/to/app".to_string(), "foo".to_string()]);
+        cmd.parse().unwrap();
+
+        let args = cmd.args();
+        let arg1 = args[0];
+        println!("command args (within the scope = {arg1:?}");
+
+        arg1
+    }
+
+    let arg1 = returns_one_of_cmd_args();
+    println!("command args (out of the scope) = {arg1:?}");
+}
+

--- a/tests/compile_errors/lifetime_of_cmd_args.stderr
+++ b/tests/compile_errors/lifetime_of_cmd_args.stderr
@@ -1,0 +1,16 @@
+warning: unused import: `cliargs::Cmd`
+ --> tests/compile_errors/lifetime_of_cmd_args.rs:1:5
+  |
+1 | use cliargs::Cmd;
+  |     ^^^^^^^^^^^^
+  |
+  = note: `#[warn(unused_imports)]` on by default
+
+error[E0515]: cannot return value referencing local variable `cmd`
+  --> tests/compile_errors/lifetime_of_cmd_args.rs:12:9
+   |
+8  |         let args = cmd.args();
+   |                    --- `cmd` is borrowed here
+...
+12 |         arg1
+   |         ^^^^ returns a value referencing data owned by the current function

--- a/tests/compile_errors/lifetime_of_cmd_name.rs
+++ b/tests/compile_errors/lifetime_of_cmd_name.rs
@@ -1,0 +1,16 @@
+use cliargs::Cmd;
+
+fn main() {
+    fn returns_cmd_name() -> &'static str {
+        let mut cmd = Cmd::with_strings(["/path/to/app".to_string()]);
+        cmd.parse().unwrap();
+
+        let name = cmd.name();
+        println!("command name (within the scope = {name}");
+
+        name
+    }
+
+    let name = returns_cmd_name();
+    println!("command name (out of the scope) = {name}");
+}

--- a/tests/compile_errors/lifetime_of_cmd_name.stderr
+++ b/tests/compile_errors/lifetime_of_cmd_name.stderr
@@ -1,0 +1,8 @@
+error[E0515]: cannot return value referencing local variable `cmd`
+  --> tests/compile_errors/lifetime_of_cmd_name.rs:11:9
+   |
+8  |         let name = cmd.name();
+   |                    --- `cmd` is borrowed here
+...
+11 |         name
+   |         ^^^^ returns a value referencing data owned by the current function

--- a/tests/compile_errors/lifetime_of_cmd_opt_arg.rs
+++ b/tests/compile_errors/lifetime_of_cmd_opt_arg.rs
@@ -1,0 +1,17 @@
+use cliargs::Cmd;
+
+fn main() {
+    fn returns_opt_arg() -> &'static str {
+        let mut cmd =
+            cliargs::Cmd::with_strings(["/path/to/app".to_string(), "--foo=bar".to_string()]);
+        cmd.parse().unwrap();
+
+        let opt_arg = cmd.opt_arg("foo").unwrap();
+        println!("option arg (within the scope = {opt_arg:?}");
+
+        opt_arg
+    }
+
+    let opt_arg = returns_opt_arg();
+    println!("option arg (out of the scope) = {opt_arg:?}");
+}

--- a/tests/compile_errors/lifetime_of_cmd_opt_arg.stderr
+++ b/tests/compile_errors/lifetime_of_cmd_opt_arg.stderr
@@ -1,0 +1,16 @@
+warning: unused import: `cliargs::Cmd`
+ --> tests/compile_errors/lifetime_of_cmd_opt_arg.rs:1:5
+  |
+1 | use cliargs::Cmd;
+  |     ^^^^^^^^^^^^
+  |
+  = note: `#[warn(unused_imports)]` on by default
+
+error[E0515]: cannot return value referencing local variable `cmd`
+  --> tests/compile_errors/lifetime_of_cmd_opt_arg.rs:12:9
+   |
+9  |         let opt_arg = cmd.opt_arg("foo").unwrap();
+   |                       --- `cmd` is borrowed here
+...
+12 |         opt_arg
+   |         ^^^^^^^ returns a value referencing data owned by the current function

--- a/tests/compile_errors/lifetime_of_cmd_opt_args.rs
+++ b/tests/compile_errors/lifetime_of_cmd_opt_args.rs
@@ -1,0 +1,17 @@
+use cliargs::Cmd;
+
+fn main() {
+    fn returns_one_of_opt_args() -> &'static str {
+        let mut cmd =
+            cliargs::Cmd::with_strings(["/path/to/app".to_string(), "--foo=bar".to_string()]);
+        cmd.parse().unwrap();
+
+        let opt_args = cmd.opt_args("foo").unwrap();
+        println!("option arg (within the scope = {:?}", opt_args[0]);
+
+        opt_args[0]
+    }
+
+    let opt_arg = returns_one_of_opt_args();
+    println!("option arg (out of the scope) = {opt_arg:?}");
+}

--- a/tests/compile_errors/lifetime_of_cmd_opt_args.stderr
+++ b/tests/compile_errors/lifetime_of_cmd_opt_args.stderr
@@ -1,0 +1,16 @@
+warning: unused import: `cliargs::Cmd`
+ --> tests/compile_errors/lifetime_of_cmd_opt_args.rs:1:5
+  |
+1 | use cliargs::Cmd;
+  |     ^^^^^^^^^^^^
+  |
+  = note: `#[warn(unused_imports)]` on by default
+
+error[E0515]: cannot return value referencing local variable `cmd`
+  --> tests/compile_errors/lifetime_of_cmd_opt_args.rs:12:9
+   |
+9  |         let opt_args = cmd.opt_args("foo").unwrap();
+   |                        --- `cmd` is borrowed here
+...
+12 |         opt_args[0]
+   |         ^^^^^^^^^^^ returns a value referencing data owned by the current function

--- a/tests/parse_test.rs
+++ b/tests/parse_test.rs
@@ -108,3 +108,9 @@ mod tests_of_errors {
         }
     }
 }
+
+#[test]
+fn compile_error_check() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/compile_errors/*.rs");
+}


### PR DESCRIPTION
Resolves #3

This PR prevents to extend the lifetime of the references to `Cmd` attributes on function returning.

And this PR adds the test cases for occuring compile errors against these lifetime extending with **trybuild** crate.