### PR TITLE
update!: added cfgs to Cmd and changed parse_with to move ownership of its parameter

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,7 +171,7 @@
 //!     ]),
 //! ];
 //!
-//! match cmd.parse_with(&opt_cfgs) {
+//! match cmd.parse_with(opt_cfgs) {
 //!     Ok(_) => { /* ... */ },
 //!     Err(InvalidOption::OptionContainsInvalidChar { option }) => { /* ... */ },
 //!     Err(InvalidOption::UnconfiguredOption { option }) => { /* ... */ },
@@ -214,6 +214,9 @@ pub struct Cmd<'a> {
     name: &'a str,
     args: Vec<&'a str>,
     opts: HashMap<&'a str, Vec<&'a str>>,
+
+    ///
+    pub cfgs: Vec<OptCfg>,
 
     _leaked_str: Vec<&'a str>,
 }
@@ -315,6 +318,7 @@ impl<'a> Cmd<'a> {
             name: &_leaked_str[0][cmd_name_start..],
             args: Vec::new(),
             opts: HashMap::new(),
+            cfgs: Vec::new(),
             _leaked_str,
         })
     }
@@ -350,6 +354,7 @@ impl<'a> Cmd<'a> {
             name: &_leaked_str[0][cmd_name_start..],
             args: Vec::new(),
             opts: HashMap::new(),
+            cfgs: Vec::new(),
             _leaked_str,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,7 +197,7 @@ mod parse;
 
 use std::collections::HashMap;
 use std::env;
-use std::ffi;
+use std::ffi::OsString;
 use std::fmt;
 use std::mem;
 use std::path;
@@ -215,7 +215,7 @@ pub struct Cmd<'a> {
     args: Vec<&'a str>,
     opts: HashMap<&'a str, Vec<&'a str>>,
 
-    ///
+    /// The option configurations which is used to parse command line arguments.
     pub cfgs: Vec<OptCfg>,
 
     _leaked_str: Vec<&'a str>,
@@ -252,10 +252,10 @@ impl<'a> Cmd<'a> {
 
     /// Creates a `Cmd` instance with the specified iterator of [OsString]s.
     ///
-    /// [OsString]s can contain invalid unicode data, the return value of this function is
-    /// [Result] of `Cmd` or `errors::InvalidOsArg`.
+    /// [OsString]s can contain invalid unicode data, the return value of this function
+    /// is [Result] of `Cmd` or `errors::InvalidOsArg`.
     pub fn with_os_strings(
-        osargs: impl IntoIterator<Item = ffi::OsString>,
+        osargs: impl IntoIterator<Item = OsString>,
     ) -> Result<Cmd<'a>, errors::InvalidOsArg> {
         let osarg_iter = osargs.into_iter();
         let (size, _) = osarg_iter.size_hint();

--- a/tests/parse_test.rs
+++ b/tests/parse_test.rs
@@ -12,6 +12,7 @@ mod tests_of_parse {
         }
         println!("cmd = {cmd:?}");
         assert!(cmd.name().starts_with("parse_test-"));
+        assert!(cmd.cfgs.is_empty());
     }
 
     #[test]
@@ -36,6 +37,7 @@ mod tests_of_parse {
         assert_eq!(cmd.has_opt("baz"), true);
         assert_eq!(cmd.opt_arg("baz"), None);
         assert_eq!(cmd.opt_args("baz"), Some(&[] as &[&str]));
+        assert!(cmd.cfgs.is_empty());
     }
 
     #[test]
@@ -61,6 +63,7 @@ mod tests_of_parse {
         assert_eq!(cmd.has_opt("baz"), true);
         assert_eq!(cmd.opt_arg("baz"), None);
         assert_eq!(cmd.opt_args("baz"), Some(&[] as &[&str]));
+        assert!(cmd.cfgs.is_empty());
     }
 }
 

--- a/tests/parse_with_test.rs
+++ b/tests/parse_with_test.rs
@@ -27,7 +27,7 @@ mod tests_of_parse_with {
             "456".to_string(),
         ]);
 
-        if let Err(err) = cmd.parse_with(&opt_cfgs) {
+        if let Err(err) = cmd.parse_with(opt_cfgs) {
             println!("{:?}", err);
             assert!(false);
         }
@@ -42,6 +42,32 @@ mod tests_of_parse_with {
         assert_eq!(cmd.has_opt("qux"), true);
         assert_eq!(cmd.opt_arg("qux"), Some("123"));
         assert_eq!(cmd.opt_args("qux"), Some(&["123", "456"] as &[&str]));
+
+        assert_eq!(cmd.cfgs.len(), 3);
+        assert_eq!(cmd.cfgs[0].store_key, "fooBar".to_string());
+        assert_eq!(
+            cmd.cfgs[0].names,
+            vec!["foo-bar".to_string(), "f".to_string()]
+        );
+        assert_eq!(cmd.cfgs[0].has_arg, false);
+        assert_eq!(cmd.cfgs[0].is_array, false);
+        assert_eq!(cmd.cfgs[0].defaults, None);
+        assert_eq!(cmd.cfgs[0].desc, "".to_string());
+        assert_eq!(cmd.cfgs[0].arg_in_help, "".to_string());
+        assert_eq!(cmd.cfgs[1].store_key, "".to_string());
+        assert_eq!(cmd.cfgs[1].names, vec!["baz".to_string(), "b".to_string()]);
+        assert_eq!(cmd.cfgs[1].has_arg, true);
+        assert_eq!(cmd.cfgs[1].is_array, false);
+        assert_eq!(cmd.cfgs[1].defaults, None);
+        assert_eq!(cmd.cfgs[1].desc, "".to_string());
+        assert_eq!(cmd.cfgs[1].arg_in_help, "".to_string());
+        assert_eq!(cmd.cfgs[2].store_key, "".to_string());
+        assert_eq!(cmd.cfgs[2].names, vec!["qux".to_string(), "q".to_string()]);
+        assert_eq!(cmd.cfgs[2].has_arg, true);
+        assert_eq!(cmd.cfgs[2].is_array, true);
+        assert_eq!(cmd.cfgs[2].defaults, None);
+        assert_eq!(cmd.cfgs[2].desc, "".to_string());
+        assert_eq!(cmd.cfgs[2].arg_in_help, "".to_string());
     }
 }
 
@@ -78,7 +104,7 @@ mod tests_of_errors {
         if let Err(InvalidOption::OptionTakesNoArg {
             store_key: sk,
             option,
-        }) = cmd.parse_with(&opt_cfgs)
+        }) = cmd.parse_with(opt_cfgs)
         {
             assert_eq!(sk, "fooBar");
             assert_eq!(option, "f");
@@ -96,6 +122,32 @@ mod tests_of_errors {
         assert_eq!(cmd.has_opt("qux"), true);
         assert_eq!(cmd.opt_arg("qux"), Some("123"));
         assert_eq!(cmd.opt_args("qux"), Some(&["123", "456"] as &[&str]));
+
+        assert_eq!(cmd.cfgs.len(), 3);
+        assert_eq!(cmd.cfgs[0].store_key, "fooBar".to_string());
+        assert_eq!(
+            cmd.cfgs[0].names,
+            vec!["foo-bar".to_string(), "f".to_string()]
+        );
+        assert_eq!(cmd.cfgs[0].has_arg, false);
+        assert_eq!(cmd.cfgs[0].is_array, false);
+        assert_eq!(cmd.cfgs[0].defaults, None);
+        assert_eq!(cmd.cfgs[0].desc, "".to_string());
+        assert_eq!(cmd.cfgs[0].arg_in_help, "".to_string());
+        assert_eq!(cmd.cfgs[1].store_key, "".to_string());
+        assert_eq!(cmd.cfgs[1].names, vec!["baz".to_string(), "b".to_string()]);
+        assert_eq!(cmd.cfgs[1].has_arg, true);
+        assert_eq!(cmd.cfgs[1].is_array, false);
+        assert_eq!(cmd.cfgs[1].defaults, None);
+        assert_eq!(cmd.cfgs[1].desc, "".to_string());
+        assert_eq!(cmd.cfgs[1].arg_in_help, "".to_string());
+        assert_eq!(cmd.cfgs[2].store_key, "".to_string());
+        assert_eq!(cmd.cfgs[2].names, vec!["qux".to_string(), "q".to_string()]);
+        assert_eq!(cmd.cfgs[2].has_arg, true);
+        assert_eq!(cmd.cfgs[2].is_array, true);
+        assert_eq!(cmd.cfgs[2].defaults, None);
+        assert_eq!(cmd.cfgs[2].desc, "".to_string());
+        assert_eq!(cmd.cfgs[2].arg_in_help, "".to_string());
     }
 
     #[test]
@@ -126,7 +178,7 @@ mod tests_of_errors {
             option,
             opt_arg,
             details,
-        }) = cmd.parse_with(&opt_cfgs)
+        }) = cmd.parse_with(opt_cfgs)
         {
             assert_eq!(sk, "qux");
             assert_eq!(option, "q");
@@ -146,5 +198,31 @@ mod tests_of_errors {
         assert_eq!(cmd.has_opt("qux"), true);
         assert_eq!(cmd.opt_arg("qux"), Some("123"));
         assert_eq!(cmd.opt_args("qux"), Some(&["123"] as &[&str]));
+
+        assert_eq!(cmd.cfgs.len(), 3);
+        assert_eq!(cmd.cfgs[0].store_key, "fooBar".to_string());
+        assert_eq!(
+            cmd.cfgs[0].names,
+            vec!["foo-bar".to_string(), "f".to_string()]
+        );
+        assert_eq!(cmd.cfgs[0].has_arg, false);
+        assert_eq!(cmd.cfgs[0].is_array, false);
+        assert_eq!(cmd.cfgs[0].defaults, None);
+        assert_eq!(cmd.cfgs[0].desc, "".to_string());
+        assert_eq!(cmd.cfgs[0].arg_in_help, "".to_string());
+        assert_eq!(cmd.cfgs[1].store_key, "".to_string());
+        assert_eq!(cmd.cfgs[1].names, vec!["baz".to_string(), "b".to_string()]);
+        assert_eq!(cmd.cfgs[1].has_arg, true);
+        assert_eq!(cmd.cfgs[1].is_array, false);
+        assert_eq!(cmd.cfgs[1].defaults, None);
+        assert_eq!(cmd.cfgs[1].desc, "".to_string());
+        assert_eq!(cmd.cfgs[1].arg_in_help, "".to_string());
+        assert_eq!(cmd.cfgs[2].store_key, "".to_string());
+        assert_eq!(cmd.cfgs[2].names, vec!["qux".to_string(), "q".to_string()]);
+        assert_eq!(cmd.cfgs[2].has_arg, true);
+        assert_eq!(cmd.cfgs[2].is_array, true);
+        assert_eq!(cmd.cfgs[2].defaults, None);
+        assert_eq!(cmd.cfgs[2].desc, "".to_string());
+        assert_eq!(cmd.cfgs[2].arg_in_help, "".to_string());
     }
 }


### PR DESCRIPTION
This PR added the public `cfgs` field to `Cmd` struct. The value of the `cfgs` field is set from the parameter of `Cmd#parse_with` method, therefore the ownership of the parameter is needed to move. 

This change anticipates that when `parse_for` method will be added to `Cmd` struct, a way to retrieve the array f `OptCfg` generated within the method will be needed.

