### PR TITLE
chore: modified categories field in Cargo.toml to use slugs, etc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 repository = "https://github.com/sttk/cliargs-rust"
 license = "MIT"
 keywords = ["cli", "command", "line", "argument", "parse"]
-categories = ["command-line interface"]
+categories = ["command-line-interface"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/cliargs_derive/Cargo.toml
+++ b/cliargs_derive/Cargo.toml
@@ -4,13 +4,13 @@ version = "0.1.0"
 authors = ["Takayuki Sato <sttk.xslet@gmail.com>"]
 edition = "2021"
 rust-version = "1.74.1"
-description = ""
+description = "The derive macro that automatically implements some methods to parse command line arguments for a struct instnace."
 documentation = "https://docs.rs/cliargs_derive"
 readme = "README.md"
 repository = "https://github.com/sttk/cliargs-rust"
 license = "MIT"
 keywords = ["cli", "command", "line", "argument", "parse"]
-categories = ["command-line interface"]
+categories = ["command-line-interface"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Publishing was failed with the following message: `The following category slugs are not currently supported on crates.io: command-line interface`.

The reason is that the `categories` field became to have to choose in the [category slugs](https://crates.io/category_slugs).