### PR TITLE
fix: changed to simply move to cfgs field and add opt_cfgs method to Cmd

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -411,7 +411,7 @@ impl<'a> Cmd<'a> {
         }
     }
 
-    /// The option configurations which was used to parse command line arguments.
+    /// Retrieves the option configurations which was used to parse command line arguments.
     pub fn opt_cfgs(&'a self) -> &[OptCfg] {
         &self.cfgs
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -220,9 +220,7 @@ pub struct Cmd<'a> {
     name: &'a str,
     args: Vec<&'a str>,
     opts: HashMap<&'a str, Vec<&'a str>>,
-
-    /// The option configurations which is used to parse command line arguments.
-    pub cfgs: Vec<OptCfg>,
+    cfgs: Vec<OptCfg>,
 
     _leaked_strs: Vec<&'a str>,
 }
@@ -411,6 +409,11 @@ impl<'a> Cmd<'a> {
             Some(vec) => Some(&vec),
             None => None,
         }
+    }
+
+    /// The option configurations which was used to parse command line arguments.
+    pub fn opt_cfgs(&'a self) -> &[OptCfg] {
+        &self.cfgs
     }
 }
 
@@ -750,10 +753,10 @@ mod tests_of_cmd {
         #[test]
         fn should_move_by_passing_a_parameter() {
             fn move_cmd(cmd: Cmd) {
-                assert_eq!(cmd.name, "app");
-                assert_eq!(cmd.args, &["baz", "qux", "quux", "corge"]);
-                assert_eq!(cmd.opts.get("foo").unwrap(), &Vec::<&str>::new());
-                assert_eq!(cmd.opts.get("bar").unwrap(), &["ABC", "DEF"]);
+                assert_eq!(cmd.name(), "app");
+                assert_eq!(cmd.args(), &["baz", "qux", "quux", "corge"]);
+                assert_eq!(cmd.opt_args("foo").unwrap(), &Vec::<&str>::new());
+                assert_eq!(cmd.opt_args("bar").unwrap(), &["ABC", "DEF"]);
                 assert_eq!(
                     cmd._leaked_strs,
                     &[
@@ -769,21 +772,21 @@ mod tests_of_cmd {
                         "bar",
                     ]
                 );
-                assert_eq!(cmd.cfgs.len(), 2);
-                assert_eq!(cmd.cfgs[0].store_key, "");
-                assert_eq!(cmd.cfgs[0].names, &["foo"]);
-                assert_eq!(cmd.cfgs[0].has_arg, false);
-                assert_eq!(cmd.cfgs[0].is_array, false);
-                assert_eq!(cmd.cfgs[0].defaults, None);
-                assert_eq!(cmd.cfgs[0].desc, "");
-                assert_eq!(cmd.cfgs[0].arg_in_help, "");
-                assert_eq!(cmd.cfgs[1].store_key, "");
-                assert_eq!(cmd.cfgs[1].names, &["bar"]);
-                assert_eq!(cmd.cfgs[1].has_arg, true);
-                assert_eq!(cmd.cfgs[1].is_array, true);
-                assert_eq!(cmd.cfgs[1].defaults, None);
-                assert_eq!(cmd.cfgs[1].desc, "");
-                assert_eq!(cmd.cfgs[1].arg_in_help, "");
+                assert_eq!(cmd.opt_cfgs().len(), 2);
+                assert_eq!(cmd.opt_cfgs()[0].store_key, "");
+                assert_eq!(cmd.opt_cfgs()[0].names, &["foo"]);
+                assert_eq!(cmd.opt_cfgs()[0].has_arg, false);
+                assert_eq!(cmd.opt_cfgs()[0].is_array, false);
+                assert_eq!(cmd.opt_cfgs()[0].defaults, None);
+                assert_eq!(cmd.opt_cfgs()[0].desc, "");
+                assert_eq!(cmd.opt_cfgs()[0].arg_in_help, "");
+                assert_eq!(cmd.opt_cfgs()[1].store_key, "");
+                assert_eq!(cmd.opt_cfgs()[1].names, &["bar"]);
+                assert_eq!(cmd.opt_cfgs()[1].has_arg, true);
+                assert_eq!(cmd.opt_cfgs()[1].is_array, true);
+                assert_eq!(cmd.opt_cfgs()[1].defaults, None);
+                assert_eq!(cmd.opt_cfgs()[1].desc, "");
+                assert_eq!(cmd.opt_cfgs()[1].arg_in_help, "");
             }
 
             let cfgs = vec![
@@ -829,10 +832,10 @@ mod tests_of_cmd {
             }
 
             let cmd = move_cmd();
-            assert_eq!(cmd.name, "app");
-            assert_eq!(cmd.args, &["baz", "qux", "quux", "corge"]);
-            assert_eq!(cmd.opts.get("foo").unwrap(), &Vec::<&str>::new());
-            assert_eq!(cmd.opts.get("bar").unwrap(), &["ABC", "DEF"]);
+            assert_eq!(cmd.name(), "app");
+            assert_eq!(cmd.args(), &["baz", "qux", "quux", "corge"]);
+            assert_eq!(cmd.opt_args("foo").unwrap(), &Vec::<&str>::new());
+            assert_eq!(cmd.opt_args("bar").unwrap(), &["ABC", "DEF"]);
             assert_eq!(
                 cmd._leaked_strs,
                 &[
@@ -848,21 +851,21 @@ mod tests_of_cmd {
                     "bar",
                 ]
             );
-            assert_eq!(cmd.cfgs.len(), 2);
-            assert_eq!(cmd.cfgs[0].store_key, "");
-            assert_eq!(cmd.cfgs[0].names, &["foo"]);
-            assert_eq!(cmd.cfgs[0].has_arg, false);
-            assert_eq!(cmd.cfgs[0].is_array, false);
-            assert_eq!(cmd.cfgs[0].defaults, None);
-            assert_eq!(cmd.cfgs[0].desc, "");
-            assert_eq!(cmd.cfgs[0].arg_in_help, "");
-            assert_eq!(cmd.cfgs[1].store_key, "");
-            assert_eq!(cmd.cfgs[1].names, &["bar"]);
-            assert_eq!(cmd.cfgs[1].has_arg, true);
-            assert_eq!(cmd.cfgs[1].is_array, true);
-            assert_eq!(cmd.cfgs[1].defaults, None);
-            assert_eq!(cmd.cfgs[1].desc, "");
-            assert_eq!(cmd.cfgs[1].arg_in_help, "");
+            assert_eq!(cmd.opt_cfgs().len(), 2);
+            assert_eq!(cmd.opt_cfgs()[0].store_key, "");
+            assert_eq!(cmd.opt_cfgs()[0].names, &["foo"]);
+            assert_eq!(cmd.opt_cfgs()[0].has_arg, false);
+            assert_eq!(cmd.opt_cfgs()[0].is_array, false);
+            assert_eq!(cmd.opt_cfgs()[0].defaults, None);
+            assert_eq!(cmd.opt_cfgs()[0].desc, "");
+            assert_eq!(cmd.opt_cfgs()[0].arg_in_help, "");
+            assert_eq!(cmd.opt_cfgs()[1].store_key, "");
+            assert_eq!(cmd.opt_cfgs()[1].names, &["bar"]);
+            assert_eq!(cmd.opt_cfgs()[1].has_arg, true);
+            assert_eq!(cmd.opt_cfgs()[1].is_array, true);
+            assert_eq!(cmd.opt_cfgs()[1].defaults, None);
+            assert_eq!(cmd.opt_cfgs()[1].desc, "");
+            assert_eq!(cmd.opt_cfgs()[1].arg_in_help, "");
         }
 
         #[test]
@@ -891,10 +894,10 @@ mod tests_of_cmd {
             }
 
             let cmd = move_cmd();
-            assert_eq!(cmd.name, "app");
-            assert_eq!(cmd.args, &["baz", "qux", "quux", "corge"]);
-            assert_eq!(cmd.opts.get("foo").unwrap(), &Vec::<&str>::new());
-            assert_eq!(cmd.opts.get("bar").unwrap(), &["ABC", "DEF"]);
+            assert_eq!(cmd.name(), "app");
+            assert_eq!(cmd.args(), &["baz", "qux", "quux", "corge"]);
+            assert_eq!(cmd.opt_args("foo").unwrap(), &Vec::<&str>::new());
+            assert_eq!(cmd.opt_args("bar").unwrap(), &["ABC", "DEF"]);
             assert_eq!(
                 cmd._leaked_strs,
                 &[
@@ -910,21 +913,21 @@ mod tests_of_cmd {
                     "bar",
                 ]
             );
-            assert_eq!(cmd.cfgs.len(), 2);
-            assert_eq!(cmd.cfgs[0].store_key, "");
-            assert_eq!(cmd.cfgs[0].names, &["foo"]);
-            assert_eq!(cmd.cfgs[0].has_arg, false);
-            assert_eq!(cmd.cfgs[0].is_array, false);
-            assert_eq!(cmd.cfgs[0].defaults, None);
-            assert_eq!(cmd.cfgs[0].desc, "");
-            assert_eq!(cmd.cfgs[0].arg_in_help, "");
-            assert_eq!(cmd.cfgs[1].store_key, "");
-            assert_eq!(cmd.cfgs[1].names, &["bar"]);
-            assert_eq!(cmd.cfgs[1].has_arg, true);
-            assert_eq!(cmd.cfgs[1].is_array, true);
-            assert_eq!(cmd.cfgs[1].defaults, None);
-            assert_eq!(cmd.cfgs[1].desc, "");
-            assert_eq!(cmd.cfgs[1].arg_in_help, "");
+            assert_eq!(cmd.opt_cfgs().len(), 2);
+            assert_eq!(cmd.opt_cfgs()[0].store_key, "");
+            assert_eq!(cmd.opt_cfgs()[0].names, &["foo"]);
+            assert_eq!(cmd.opt_cfgs()[0].has_arg, false);
+            assert_eq!(cmd.opt_cfgs()[0].is_array, false);
+            assert_eq!(cmd.opt_cfgs()[0].defaults, None);
+            assert_eq!(cmd.opt_cfgs()[0].desc, "");
+            assert_eq!(cmd.opt_cfgs()[0].arg_in_help, "");
+            assert_eq!(cmd.opt_cfgs()[1].store_key, "");
+            assert_eq!(cmd.opt_cfgs()[1].names, &["bar"]);
+            assert_eq!(cmd.opt_cfgs()[1].has_arg, true);
+            assert_eq!(cmd.opt_cfgs()[1].is_array, true);
+            assert_eq!(cmd.opt_cfgs()[1].defaults, None);
+            assert_eq!(cmd.opt_cfgs()[1].desc, "");
+            assert_eq!(cmd.opt_cfgs()[1].arg_in_help, "");
         }
 
         #[test]
@@ -953,10 +956,10 @@ mod tests_of_cmd {
             }
 
             let cmd = move_cmd();
-            assert_eq!(cmd.name, "app");
-            assert_eq!(cmd.args, &["baz", "qux", "quux", "corge"]);
-            assert_eq!(cmd.opts.get("foo").unwrap(), &Vec::<&str>::new());
-            assert_eq!(cmd.opts.get("bar").unwrap(), &["ABC", "DEF"]);
+            assert_eq!(cmd.name(), "app");
+            assert_eq!(cmd.args(), &["baz", "qux", "quux", "corge"]);
+            assert_eq!(cmd.opt_args("foo").unwrap(), &Vec::<&str>::new());
+            assert_eq!(cmd.opt_args("bar").unwrap(), &["ABC", "DEF"]);
             assert_eq!(
                 cmd._leaked_strs,
                 &[
@@ -972,21 +975,21 @@ mod tests_of_cmd {
                     "bar",
                 ]
             );
-            assert_eq!(cmd.cfgs.len(), 2);
-            assert_eq!(cmd.cfgs[0].store_key, "");
-            assert_eq!(cmd.cfgs[0].names, &["foo"]);
-            assert_eq!(cmd.cfgs[0].has_arg, false);
-            assert_eq!(cmd.cfgs[0].is_array, false);
-            assert_eq!(cmd.cfgs[0].defaults, None);
-            assert_eq!(cmd.cfgs[0].desc, "");
-            assert_eq!(cmd.cfgs[0].arg_in_help, "");
-            assert_eq!(cmd.cfgs[1].store_key, "");
-            assert_eq!(cmd.cfgs[1].names, &["bar"]);
-            assert_eq!(cmd.cfgs[1].has_arg, true);
-            assert_eq!(cmd.cfgs[1].is_array, true);
-            assert_eq!(cmd.cfgs[1].defaults, None);
-            assert_eq!(cmd.cfgs[1].desc, "");
-            assert_eq!(cmd.cfgs[1].arg_in_help, "");
+            assert_eq!(cmd.opt_cfgs().len(), 2);
+            assert_eq!(cmd.opt_cfgs()[0].store_key, "");
+            assert_eq!(cmd.opt_cfgs()[0].names, &["foo"]);
+            assert_eq!(cmd.opt_cfgs()[0].has_arg, false);
+            assert_eq!(cmd.opt_cfgs()[0].is_array, false);
+            assert_eq!(cmd.opt_cfgs()[0].defaults, None);
+            assert_eq!(cmd.opt_cfgs()[0].desc, "");
+            assert_eq!(cmd.opt_cfgs()[0].arg_in_help, "");
+            assert_eq!(cmd.opt_cfgs()[1].store_key, "");
+            assert_eq!(cmd.opt_cfgs()[1].names, &["bar"]);
+            assert_eq!(cmd.opt_cfgs()[1].has_arg, true);
+            assert_eq!(cmd.opt_cfgs()[1].is_array, true);
+            assert_eq!(cmd.opt_cfgs()[1].defaults, None);
+            assert_eq!(cmd.opt_cfgs()[1].desc, "");
+            assert_eq!(cmd.opt_cfgs()[1].arg_in_help, "");
         }
     }
 }

--- a/src/parse/parse_for.rs
+++ b/src/parse/parse_for.rs
@@ -104,7 +104,7 @@ impl Cmd<'_> {
     ///     Err(err) => panic!("Invalid option: {}", err.option()),
     /// }
     ///
-    /// let opt_cfgs = &cmd.cfgs;
+    /// let opt_cfgs = &cmd.opt_cfgs();
     /// ```
     pub fn parse_for<T: OptStore>(&mut self, opt_store: &mut T) -> Result<(), InvalidOption> {
         let cfgs = opt_store.make_opt_cfgs();

--- a/src/parse/parse_for.rs
+++ b/src/parse/parse_for.rs
@@ -104,7 +104,7 @@ impl Cmd<'_> {
     ///     Err(err) => panic!("Invalid option: {}", err.option()),
     /// }
     ///
-    /// let opt_cfgs = &cmd.opt_cfgs();
+    /// let cfgs = cmd.opt_cfgs();
     /// ```
     pub fn parse_for<T: OptStore>(&mut self, opt_store: &mut T) -> Result<(), InvalidOption> {
         let cfgs = opt_store.make_opt_cfgs();

--- a/src/parse/parse_with.rs
+++ b/src/parse/parse_with.rs
@@ -7,7 +7,6 @@ use crate::errors::InvalidOption;
 use crate::Cmd;
 use crate::OptCfg;
 use std::collections::HashMap;
-use std::mem;
 
 impl<'a> Cmd<'a> {
     /// Parses command line arguments with option configurations.
@@ -61,7 +60,7 @@ impl<'a> Cmd<'a> {
     /// ```
     pub fn parse_with(&mut self, opt_cfgs: Vec<OptCfg>) -> Result<(), InvalidOption> {
         let result = self._parse_with(&opt_cfgs);
-        let _ = mem::replace(&mut self.cfgs, opt_cfgs);
+        self.cfgs = opt_cfgs;
         result
     }
 

--- a/tests/parse_for_test.rs
+++ b/tests/parse_for_test.rs
@@ -48,16 +48,16 @@ mod tests_of_parse_for {
         assert_eq!(cmd.opt_arg("foo_bar"), None);
         assert_eq!(cmd.opt_args("foo_bar"), Some(&[] as &[&str]));
 
-        assert_eq!(cmd.cfgs.len(), 1);
-        assert_eq!(cmd.cfgs[0].store_key, "foo_bar");
+        assert_eq!(cmd.opt_cfgs().len(), 1);
+        assert_eq!(cmd.opt_cfgs()[0].store_key, "foo_bar");
         assert_eq!(
-            cmd.cfgs[0].names,
+            cmd.opt_cfgs()[0].names,
             ["f".to_string(), "b".to_string(), "foo-bar".to_string()]
         );
-        assert_eq!(cmd.cfgs[0].has_arg, false);
-        assert_eq!(cmd.cfgs[0].is_array, false);
-        assert_eq!(cmd.cfgs[0].defaults, None);
-        assert_eq!(cmd.cfgs[0].desc, "The FooBar flag".to_string());
-        assert_eq!(cmd.cfgs[0].arg_in_help, "".to_string());
+        assert_eq!(cmd.opt_cfgs()[0].has_arg, false);
+        assert_eq!(cmd.opt_cfgs()[0].is_array, false);
+        assert_eq!(cmd.opt_cfgs()[0].defaults, None);
+        assert_eq!(cmd.opt_cfgs()[0].desc, "The FooBar flag".to_string());
+        assert_eq!(cmd.opt_cfgs()[0].arg_in_help, "".to_string());
     }
 }

--- a/tests/parse_test.rs
+++ b/tests/parse_test.rs
@@ -12,7 +12,7 @@ mod tests_of_parse {
         }
         println!("cmd = {cmd:?}");
         assert!(cmd.name().starts_with("parse_test-"));
-        assert!(cmd.cfgs.is_empty());
+        assert!(cmd.opt_cfgs().is_empty());
     }
 
     #[test]
@@ -37,7 +37,7 @@ mod tests_of_parse {
         assert_eq!(cmd.has_opt("baz"), true);
         assert_eq!(cmd.opt_arg("baz"), None);
         assert_eq!(cmd.opt_args("baz"), Some(&[] as &[&str]));
-        assert!(cmd.cfgs.is_empty());
+        assert!(cmd.opt_cfgs().is_empty());
     }
 
     #[test]
@@ -63,7 +63,7 @@ mod tests_of_parse {
         assert_eq!(cmd.has_opt("baz"), true);
         assert_eq!(cmd.opt_arg("baz"), None);
         assert_eq!(cmd.opt_args("baz"), Some(&[] as &[&str]));
-        assert!(cmd.cfgs.is_empty());
+        assert!(cmd.opt_cfgs().is_empty());
     }
 }
 

--- a/tests/parse_with_test.rs
+++ b/tests/parse_with_test.rs
@@ -43,31 +43,37 @@ mod tests_of_parse_with {
         assert_eq!(cmd.opt_arg("qux"), Some("123"));
         assert_eq!(cmd.opt_args("qux"), Some(&["123", "456"] as &[&str]));
 
-        assert_eq!(cmd.cfgs.len(), 3);
-        assert_eq!(cmd.cfgs[0].store_key, "fooBar".to_string());
+        assert_eq!(cmd.opt_cfgs().len(), 3);
+        assert_eq!(cmd.opt_cfgs()[0].store_key, "fooBar".to_string());
         assert_eq!(
-            cmd.cfgs[0].names,
+            cmd.opt_cfgs()[0].names,
             vec!["foo-bar".to_string(), "f".to_string()]
         );
-        assert_eq!(cmd.cfgs[0].has_arg, false);
-        assert_eq!(cmd.cfgs[0].is_array, false);
-        assert_eq!(cmd.cfgs[0].defaults, None);
-        assert_eq!(cmd.cfgs[0].desc, "".to_string());
-        assert_eq!(cmd.cfgs[0].arg_in_help, "".to_string());
-        assert_eq!(cmd.cfgs[1].store_key, "".to_string());
-        assert_eq!(cmd.cfgs[1].names, vec!["baz".to_string(), "b".to_string()]);
-        assert_eq!(cmd.cfgs[1].has_arg, true);
-        assert_eq!(cmd.cfgs[1].is_array, false);
-        assert_eq!(cmd.cfgs[1].defaults, None);
-        assert_eq!(cmd.cfgs[1].desc, "".to_string());
-        assert_eq!(cmd.cfgs[1].arg_in_help, "".to_string());
-        assert_eq!(cmd.cfgs[2].store_key, "".to_string());
-        assert_eq!(cmd.cfgs[2].names, vec!["qux".to_string(), "q".to_string()]);
-        assert_eq!(cmd.cfgs[2].has_arg, true);
-        assert_eq!(cmd.cfgs[2].is_array, true);
-        assert_eq!(cmd.cfgs[2].defaults, None);
-        assert_eq!(cmd.cfgs[2].desc, "".to_string());
-        assert_eq!(cmd.cfgs[2].arg_in_help, "".to_string());
+        assert_eq!(cmd.opt_cfgs()[0].has_arg, false);
+        assert_eq!(cmd.opt_cfgs()[0].is_array, false);
+        assert_eq!(cmd.opt_cfgs()[0].defaults, None);
+        assert_eq!(cmd.opt_cfgs()[0].desc, "".to_string());
+        assert_eq!(cmd.opt_cfgs()[0].arg_in_help, "".to_string());
+        assert_eq!(cmd.opt_cfgs()[1].store_key, "".to_string());
+        assert_eq!(
+            cmd.opt_cfgs()[1].names,
+            vec!["baz".to_string(), "b".to_string()]
+        );
+        assert_eq!(cmd.opt_cfgs()[1].has_arg, true);
+        assert_eq!(cmd.opt_cfgs()[1].is_array, false);
+        assert_eq!(cmd.opt_cfgs()[1].defaults, None);
+        assert_eq!(cmd.opt_cfgs()[1].desc, "".to_string());
+        assert_eq!(cmd.opt_cfgs()[1].arg_in_help, "".to_string());
+        assert_eq!(cmd.opt_cfgs()[2].store_key, "".to_string());
+        assert_eq!(
+            cmd.opt_cfgs()[2].names,
+            vec!["qux".to_string(), "q".to_string()]
+        );
+        assert_eq!(cmd.opt_cfgs()[2].has_arg, true);
+        assert_eq!(cmd.opt_cfgs()[2].is_array, true);
+        assert_eq!(cmd.opt_cfgs()[2].defaults, None);
+        assert_eq!(cmd.opt_cfgs()[2].desc, "".to_string());
+        assert_eq!(cmd.opt_cfgs()[2].arg_in_help, "".to_string());
     }
 }
 
@@ -123,31 +129,37 @@ mod tests_of_errors {
         assert_eq!(cmd.opt_arg("qux"), Some("123"));
         assert_eq!(cmd.opt_args("qux"), Some(&["123", "456"] as &[&str]));
 
-        assert_eq!(cmd.cfgs.len(), 3);
-        assert_eq!(cmd.cfgs[0].store_key, "fooBar".to_string());
+        assert_eq!(cmd.opt_cfgs().len(), 3);
+        assert_eq!(cmd.opt_cfgs()[0].store_key, "fooBar".to_string());
         assert_eq!(
-            cmd.cfgs[0].names,
+            cmd.opt_cfgs()[0].names,
             vec!["foo-bar".to_string(), "f".to_string()]
         );
-        assert_eq!(cmd.cfgs[0].has_arg, false);
-        assert_eq!(cmd.cfgs[0].is_array, false);
-        assert_eq!(cmd.cfgs[0].defaults, None);
-        assert_eq!(cmd.cfgs[0].desc, "".to_string());
-        assert_eq!(cmd.cfgs[0].arg_in_help, "".to_string());
-        assert_eq!(cmd.cfgs[1].store_key, "".to_string());
-        assert_eq!(cmd.cfgs[1].names, vec!["baz".to_string(), "b".to_string()]);
-        assert_eq!(cmd.cfgs[1].has_arg, true);
-        assert_eq!(cmd.cfgs[1].is_array, false);
-        assert_eq!(cmd.cfgs[1].defaults, None);
-        assert_eq!(cmd.cfgs[1].desc, "".to_string());
-        assert_eq!(cmd.cfgs[1].arg_in_help, "".to_string());
-        assert_eq!(cmd.cfgs[2].store_key, "".to_string());
-        assert_eq!(cmd.cfgs[2].names, vec!["qux".to_string(), "q".to_string()]);
-        assert_eq!(cmd.cfgs[2].has_arg, true);
-        assert_eq!(cmd.cfgs[2].is_array, true);
-        assert_eq!(cmd.cfgs[2].defaults, None);
-        assert_eq!(cmd.cfgs[2].desc, "".to_string());
-        assert_eq!(cmd.cfgs[2].arg_in_help, "".to_string());
+        assert_eq!(cmd.opt_cfgs()[0].has_arg, false);
+        assert_eq!(cmd.opt_cfgs()[0].is_array, false);
+        assert_eq!(cmd.opt_cfgs()[0].defaults, None);
+        assert_eq!(cmd.opt_cfgs()[0].desc, "".to_string());
+        assert_eq!(cmd.opt_cfgs()[0].arg_in_help, "".to_string());
+        assert_eq!(cmd.opt_cfgs()[1].store_key, "".to_string());
+        assert_eq!(
+            cmd.opt_cfgs()[1].names,
+            vec!["baz".to_string(), "b".to_string()]
+        );
+        assert_eq!(cmd.opt_cfgs()[1].has_arg, true);
+        assert_eq!(cmd.opt_cfgs()[1].is_array, false);
+        assert_eq!(cmd.opt_cfgs()[1].defaults, None);
+        assert_eq!(cmd.opt_cfgs()[1].desc, "".to_string());
+        assert_eq!(cmd.opt_cfgs()[1].arg_in_help, "".to_string());
+        assert_eq!(cmd.opt_cfgs()[2].store_key, "".to_string());
+        assert_eq!(
+            cmd.opt_cfgs()[2].names,
+            vec!["qux".to_string(), "q".to_string()]
+        );
+        assert_eq!(cmd.opt_cfgs()[2].has_arg, true);
+        assert_eq!(cmd.opt_cfgs()[2].is_array, true);
+        assert_eq!(cmd.opt_cfgs()[2].defaults, None);
+        assert_eq!(cmd.opt_cfgs()[2].desc, "".to_string());
+        assert_eq!(cmd.opt_cfgs()[2].arg_in_help, "".to_string());
     }
 
     #[test]
@@ -199,30 +211,36 @@ mod tests_of_errors {
         assert_eq!(cmd.opt_arg("qux"), Some("123"));
         assert_eq!(cmd.opt_args("qux"), Some(&["123"] as &[&str]));
 
-        assert_eq!(cmd.cfgs.len(), 3);
-        assert_eq!(cmd.cfgs[0].store_key, "fooBar".to_string());
+        assert_eq!(cmd.opt_cfgs().len(), 3);
+        assert_eq!(cmd.opt_cfgs()[0].store_key, "fooBar".to_string());
         assert_eq!(
-            cmd.cfgs[0].names,
+            cmd.opt_cfgs()[0].names,
             vec!["foo-bar".to_string(), "f".to_string()]
         );
-        assert_eq!(cmd.cfgs[0].has_arg, false);
-        assert_eq!(cmd.cfgs[0].is_array, false);
-        assert_eq!(cmd.cfgs[0].defaults, None);
-        assert_eq!(cmd.cfgs[0].desc, "".to_string());
-        assert_eq!(cmd.cfgs[0].arg_in_help, "".to_string());
-        assert_eq!(cmd.cfgs[1].store_key, "".to_string());
-        assert_eq!(cmd.cfgs[1].names, vec!["baz".to_string(), "b".to_string()]);
-        assert_eq!(cmd.cfgs[1].has_arg, true);
-        assert_eq!(cmd.cfgs[1].is_array, false);
-        assert_eq!(cmd.cfgs[1].defaults, None);
-        assert_eq!(cmd.cfgs[1].desc, "".to_string());
-        assert_eq!(cmd.cfgs[1].arg_in_help, "".to_string());
-        assert_eq!(cmd.cfgs[2].store_key, "".to_string());
-        assert_eq!(cmd.cfgs[2].names, vec!["qux".to_string(), "q".to_string()]);
-        assert_eq!(cmd.cfgs[2].has_arg, true);
-        assert_eq!(cmd.cfgs[2].is_array, true);
-        assert_eq!(cmd.cfgs[2].defaults, None);
-        assert_eq!(cmd.cfgs[2].desc, "".to_string());
-        assert_eq!(cmd.cfgs[2].arg_in_help, "".to_string());
+        assert_eq!(cmd.opt_cfgs()[0].has_arg, false);
+        assert_eq!(cmd.opt_cfgs()[0].is_array, false);
+        assert_eq!(cmd.opt_cfgs()[0].defaults, None);
+        assert_eq!(cmd.opt_cfgs()[0].desc, "".to_string());
+        assert_eq!(cmd.opt_cfgs()[0].arg_in_help, "".to_string());
+        assert_eq!(cmd.opt_cfgs()[1].store_key, "".to_string());
+        assert_eq!(
+            cmd.opt_cfgs()[1].names,
+            vec!["baz".to_string(), "b".to_string()]
+        );
+        assert_eq!(cmd.opt_cfgs()[1].has_arg, true);
+        assert_eq!(cmd.opt_cfgs()[1].is_array, false);
+        assert_eq!(cmd.opt_cfgs()[1].defaults, None);
+        assert_eq!(cmd.opt_cfgs()[1].desc, "".to_string());
+        assert_eq!(cmd.opt_cfgs()[1].arg_in_help, "".to_string());
+        assert_eq!(cmd.opt_cfgs()[2].store_key, "".to_string());
+        assert_eq!(
+            cmd.opt_cfgs()[2].names,
+            vec!["qux".to_string(), "q".to_string()]
+        );
+        assert_eq!(cmd.opt_cfgs()[2].has_arg, true);
+        assert_eq!(cmd.opt_cfgs()[2].is_array, true);
+        assert_eq!(cmd.opt_cfgs()[2].defaults, None);
+        assert_eq!(cmd.opt_cfgs()[2].desc, "".to_string());
+        assert_eq!(cmd.opt_cfgs()[2].arg_in_help, "".to_string());
     }
 }


### PR DESCRIPTION
Because it's unnecessary to use `std::mem::replace` for setting `cfgs` field of `Cmd`, and a public field can be overridden.