### PR TITLE
update: renamed take_args to take_opt_args

### DIFF
--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -14,7 +14,7 @@ fn parse_args<'a, F1, F2, F3>(
     args: &[&'a str],
     mut collect_args: F1,
     mut collect_opts: F2,
-    take_args: F3,
+    take_opt_args: F3,
 ) -> Result<(), InvalidOption>
 where
     F1: FnMut(&'a str),
@@ -84,7 +84,7 @@ where
             }
 
             if i == arg.len() {
-                if take_args(arg) && i_arg < args.len() - 1 {
+                if take_opt_args(arg) && i_arg < args.len() - 1 {
                     prev_opt_taking_args = arg;
                     continue 'L0;
                 }
@@ -148,7 +148,7 @@ where
             }
 
             if i == arg.len() && !name.is_empty() {
-                if take_args(name) && i_arg < args.len() - 1 {
+                if take_opt_args(name) && i_arg < args.len() - 1 {
                     prev_opt_taking_args = name;
                 } else {
                     match collect_opts(name, None) {

--- a/src/parse/parse.rs
+++ b/src/parse/parse.rs
@@ -49,14 +49,14 @@ impl<'a> Cmd<'a> {
             Ok(())
         };
 
-        let take_args = |_arg: &str| false;
+        let take_opt_args = |_arg: &str| false;
 
         if !self._leaked_strs.is_empty() {
             match parse_args(
                 &self._leaked_strs[1..],
                 collect_args,
                 collect_opts,
-                take_args,
+                take_opt_args,
             ) {
                 Ok(_) => {}
                 Err(err) => return Err(err),

--- a/src/parse/parse_with.rs
+++ b/src/parse/parse_with.rs
@@ -140,7 +140,7 @@ impl<'a> Cmd<'a> {
             return Ok(());
         }
 
-        let take_args = |opt: &str| {
+        let take_opt_args = |opt: &str| {
             if let Some(i) = cfg_map.get(opt) {
                 return opt_cfgs[*i].has_arg;
             }
@@ -237,7 +237,7 @@ impl<'a> Cmd<'a> {
             &self._leaked_strs[1..],
             collect_args,
             collect_opts,
-            take_args,
+            take_opt_args,
         );
 
         for str_ref in str_refs {


### PR DESCRIPTION
This PR renames the closure function name `take_args` to `take_opt_args` because  the word `args` is confusable between command args and option args. 