### PR TITLE
update: changed the return of parse_args and collect_args to support sub command

### DIFF
--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -15,9 +15,9 @@ fn parse_args<'a, F1, F2, F3>(
     mut collect_args: F1,
     mut collect_opts: F2,
     take_opt_args: F3,
-) -> Result<(), InvalidOption>
+) -> Result<usize, InvalidOption>
 where
-    F1: FnMut(&'a str),
+    F1: FnMut(&'a str) -> bool,
     F2: FnMut(&'a str, Option<&'a str>) -> Result<(), InvalidOption>,
     F3: Fn(&str) -> bool,
 {
@@ -27,7 +27,9 @@ where
 
     'L0: for (i_arg, arg) in args.iter().enumerate() {
         if is_non_opt {
-            collect_args(arg);
+            if collect_args(arg) {
+                return Ok(i_arg);
+            }
         } else if !prev_opt_taking_args.is_empty() {
             match collect_opts(prev_opt_taking_args, Some(arg)) {
                 Err(err) => {
@@ -100,7 +102,9 @@ where
             }
         } else if arg.starts_with("-") {
             if arg.len() == 1 {
-                collect_args(arg);
+                if collect_args(arg) {
+                    return Ok(i_arg);
+                }
                 continue 'L0;
             }
 
@@ -163,13 +167,15 @@ where
                 }
             }
         } else {
-            collect_args(arg);
+            if collect_args(arg) {
+                return Ok(i_arg);
+            }
         }
     }
 
     match first_err {
         Some(err) => Err(err),
-        None => Ok(()),
+        None => Ok(args.len()),
     }
 }
 

--- a/src/parse/parse.rs
+++ b/src/parse/parse.rs
@@ -39,6 +39,7 @@ impl<'a> Cmd<'a> {
     pub fn parse(&mut self) -> Result<(), InvalidOption> {
         let collect_args = |arg| {
             self.args.push(arg);
+            false
         };
 
         let collect_opts = |name, option| {

--- a/src/parse/parse_with.rs
+++ b/src/parse/parse_with.rs
@@ -149,6 +149,7 @@ impl<'a> Cmd<'a> {
 
         let collect_args = |arg| {
             self.args.push(arg);
+            false
         };
 
         let mut str_refs: Vec<&'a str> = Vec::with_capacity(opt_cfgs.len());


### PR DESCRIPTION
This PR changes  the return type of `parse_args` function from `Result<(), InvalidOption>` to `Result(usize, InvalidOption>` and  `collect_args` closure function from `void` to `bool` to support sub command.

If the return value of `collect_args` is `true`, the arg is a sub command name, and then, `parse_args` returns `Ok(<arg index of sub command>)`.