### PR TITLE
new: changed to support sub command

### DIFF
--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -28,13 +28,13 @@ where
 
     'L0: for (i_arg, arg) in args.iter().enumerate() {
         if is_non_opt {
-            collect_args(arg);
             if until_1st_arg {
                 if let Some(err) = first_err {
                     return Err(err);
                 }
                 return Ok(Some(i_arg));
             }
+            collect_args(arg);
         } else if !prev_opt_taking_args.is_empty() {
             match collect_opts(prev_opt_taking_args, Some(arg)) {
                 Err(err) => {
@@ -107,13 +107,13 @@ where
             }
         } else if arg.starts_with("-") {
             if arg.len() == 1 {
-                collect_args(arg);
                 if until_1st_arg {
                     if let Some(err) = first_err {
                         return Err(err);
                     }
                     return Ok(Some(i_arg));
                 }
+                collect_args(arg);
                 continue 'L0;
             }
 
@@ -176,13 +176,13 @@ where
                 }
             }
         } else {
-            collect_args(arg);
             if until_1st_arg {
                 if let Some(err) = first_err {
                     return Err(err);
                 }
                 return Ok(Some(i_arg));
             }
+            collect_args(arg);
         }
     }
 

--- a/src/parse/parse.rs
+++ b/src/parse/parse.rs
@@ -6,7 +6,7 @@ use super::parse_args;
 use crate::errors::InvalidOption;
 use crate::Cmd;
 
-impl<'a> Cmd<'a> {
+impl<'b, 'a> Cmd<'a> {
     /// Parses command line arguments without configurations.
     ///
     /// This method divides command line arguments into options and command arguments based on
@@ -28,6 +28,7 @@ impl<'a> Cmd<'a> {
     /// use cliargs::errors::InvalidOption;
     ///
     /// let mut cmd = Cmd::with_strings(vec![ /* ... */ ]);
+    ///
     /// match cmd.parse() {
     ///     Ok(_) => { /* ... */ },
     ///     Err(InvalidOption::OptionContainsInvalidChar { option }) => {
@@ -51,9 +52,9 @@ impl<'a> Cmd<'a> {
 
         let take_opt_args = |_arg: &str| false;
 
-        if !self._leaked_strs.is_empty() {
+        if self._num_of_args > 0 {
             match parse_args(
-                &self._leaked_strs[1..],
+                &self._leaked_strs[1..(self._num_of_args)],
                 collect_args,
                 collect_opts,
                 take_opt_args,
@@ -65,6 +66,75 @@ impl<'a> Cmd<'a> {
         }
 
         Ok(())
+    }
+
+    /// Parses command line arguments without configurations but stops parsing when encountering
+    /// first command argument.
+    ///
+    /// This method creates and returns a new [Cmd] instance that holds the command line arguments
+    /// starting from the first command argument.
+    ///
+    /// This method divides command line arguments into options and command arguments based on
+    /// simple rules that are almost the same as POSIX & GNU:
+    /// arguments staring with `-` or `--` are treated as options, and others are treated as command
+    /// arguments.
+    /// If an `=` is found within an option, the part before the `=` is treated as the option name,
+    /// and the part after the `=` is treated as the option argument.
+    /// Options starting with `--` are long options and option starting with `-` are short options.
+    /// Multiple short options can be concatenated into a single command line argument.
+    /// If an argument is exactly `--`, all subsequent arguments are treated as command arguments.
+    ///
+    /// Since the results of parsing are stored into this `Cmd` instance, this method returns a
+    /// [Result] which contains an unit value (`()`) if succeeding, or a `errors::InvalidOption`
+    /// if failing.
+    ///
+    /// ```rust
+    /// use cliargs::Cmd;
+    /// use cliargs::errors::InvalidOption;
+    ///
+    /// let mut cmd = Cmd::with_strings(vec![ /* ... */ ]);
+    ///
+    /// match cmd.parse_until_sub_cmd() {
+    ///     Ok(Some(mut sub_cmd)) => {
+    ///         let sub_cmd_name = sub_cmd.name();
+    ///         match sub_cmd.parse() {
+    ///             Ok(_) => { /* ... */ },
+    ///             Err(err) => panic!("Invalid option: {}", err.option()),
+    ///         }
+    ///     },
+    ///     Ok(None) => { /* ... */ },
+    ///     Err(InvalidOption::OptionContainsInvalidChar { option }) => {
+    ///         panic!("Option contains invalid character: {option}");
+    ///     },
+    ///     Err(err) => panic!("Invalid option: {}", err.option()),
+    /// }
+    /// ```
+    pub fn parse_until_sub_cmd(&mut self) -> Result<Option<Cmd<'b>>, InvalidOption> {
+        let collect_args = |_arg| {};
+
+        let collect_opts = |name, option| {
+            let vec = self.opts.entry(name).or_insert_with(|| Vec::new());
+            if let Some(arg) = option {
+                vec.push(arg);
+            }
+            Ok(())
+        };
+
+        let take_opt_args = |_arg: &str| false;
+
+        if self._num_of_args > 0 {
+            if let Some(idx) = parse_args(
+                &self._leaked_strs[1..(self._num_of_args)],
+                collect_args,
+                collect_opts,
+                take_opt_args,
+                true,
+            )? {
+                return Ok(Some(self.sub_cmd(idx + 1))); // +1, because parse_args parses from 1.
+            }
+        }
+
+        Ok(None)
     }
 }
 
@@ -570,5 +640,174 @@ mod tests_of_cmd {
             assert_eq!(cmd.has_opt("2"), false);
             assert_eq!(cmd.has_opt("3"), false);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests_of_parse_until_sub_cmd {
+    use super::*;
+
+    #[test]
+    fn test_if_command_line_arguments_contains_no_command_argument_and_option() {
+        let ui_args = vec!["/path/to/app".to_string()];
+        let mut cmd = Cmd::with_strings(ui_args);
+
+        match cmd.parse_until_sub_cmd() {
+            Ok(None) => {}
+            Ok(Some(_)) => assert!(false),
+            Err(_) => assert!(false),
+        }
+
+        assert_eq!(cmd.name(), "app");
+        assert_eq!(cmd.args(), &[] as &[&str]);
+    }
+
+    #[test]
+    fn test_if_command_line_arguments_contains_only_command_arguments() {
+        let ui_args = vec![
+            "/path/to/app".to_string(),
+            "foo".to_string(),
+            "bar".to_string(),
+        ];
+        let mut cmd = Cmd::with_strings(ui_args);
+
+        match cmd.parse_until_sub_cmd() {
+            Ok(Some(mut sub_cmd)) => {
+                assert_eq!(sub_cmd.name(), "foo");
+                assert_eq!(sub_cmd.args(), &[] as &[&str]);
+
+                match sub_cmd.parse() {
+                    Ok(_) => {}
+                    Err(_) => assert!(false),
+                }
+
+                assert_eq!(sub_cmd.name(), "foo");
+                assert_eq!(sub_cmd.args(), &["bar"]);
+            }
+            Ok(None) => assert!(false),
+            Err(_) => assert!(false),
+        }
+
+        assert_eq!(cmd.name(), "app");
+        assert_eq!(cmd.args(), &[] as &[&str]);
+
+        //
+
+        let f = || {
+            let ui_args = vec![
+                "/path/to/app".to_string(),
+                "foo".to_string(),
+                "bar".to_string(),
+            ];
+            let mut cmd = Cmd::with_strings(ui_args);
+
+            if let Some(mut sub_cmd) = cmd.parse_until_sub_cmd()? {
+                assert_eq!(sub_cmd.name(), "foo");
+                assert_eq!(sub_cmd.args(), &[] as &[&str]);
+
+                match sub_cmd.parse() {
+                    Ok(_) => {}
+                    Err(_) => assert!(false),
+                }
+
+                assert_eq!(sub_cmd.name(), "foo");
+                assert_eq!(sub_cmd.args(), &["bar"]);
+
+                assert_eq!(cmd.name(), "app");
+                assert_eq!(cmd.args(), &[] as &[&str]);
+            } else {
+                assert_eq!(cmd.name(), "app");
+                assert_eq!(cmd.args(), &[] as &[&str]);
+            }
+
+            Ok::<(), InvalidOption>(())
+        };
+        let _ = f();
+    }
+
+    #[test]
+    fn test_if_command_line_arguments_contains_only_command_options() {
+        let ui_args = vec![
+            "/path/to/app".to_string(),
+            "--foo".to_string(),
+            "-b".to_string(),
+        ];
+        let mut cmd = Cmd::with_strings(ui_args);
+
+        match cmd.parse_until_sub_cmd() {
+            Ok(None) => {}
+            Ok(Some(_)) => assert!(false),
+            Err(_) => assert!(false),
+        }
+
+        assert_eq!(cmd.name(), "app");
+        assert_eq!(cmd.args(), &[] as &[&str]);
+        assert_eq!(cmd.has_opt("foo"), true);
+        assert_eq!(cmd.has_opt("b"), true);
+        assert_eq!(cmd.opt_arg("foo"), None);
+        assert_eq!(cmd.opt_arg("b"), None);
+    }
+
+    #[test]
+    fn test_if_command_line_arguments_contains_both_command_arguments_and_options() {
+        let ui_args = vec![
+            "/path/to/app".to_string(),
+            "--foo=123".to_string(),
+            "bar".to_string(),
+            "--baz".to_string(),
+            "-q=ABC".to_string(),
+            "quux".to_string(),
+        ];
+        let mut cmd = Cmd::with_strings(ui_args);
+
+        if let Some(mut sub_cmd) = cmd.parse_until_sub_cmd().unwrap() {
+            assert_eq!(sub_cmd.name(), "bar");
+            assert_eq!(sub_cmd.args(), &[] as &[&str]);
+            assert_eq!(cmd.has_opt("baz"), false);
+            assert_eq!(cmd.opt_arg("baz"), None);
+            assert_eq!(cmd.has_opt("q"), false);
+            assert_eq!(cmd.opt_arg("q"), None);
+
+            match sub_cmd.parse() {
+                Ok(_) => {}
+                Err(_) => assert!(false),
+            }
+
+            assert_eq!(sub_cmd.name(), "bar");
+            assert_eq!(sub_cmd.args(), &["quux"]);
+            assert_eq!(sub_cmd.has_opt("baz"), true);
+            assert_eq!(sub_cmd.opt_arg("baz"), None);
+            assert_eq!(sub_cmd.has_opt("q"), true);
+            assert_eq!(sub_cmd.opt_arg("q"), Some("ABC"));
+        }
+
+        assert_eq!(cmd.name(), "app");
+        assert_eq!(cmd.args(), &[] as &[&str]);
+        assert_eq!(cmd.has_opt("foo"), true);
+        assert_eq!(cmd.opt_arg("foo"), Some("123"));
+    }
+
+    #[test]
+    fn test_if_fail_to_parse() {
+        let ui_args = vec![
+            "/path/to/app".to_string(),
+            "--f#o".to_string(),
+            "bar".to_string(),
+        ];
+        let mut cmd = Cmd::with_strings(ui_args);
+
+        match cmd.parse_until_sub_cmd() {
+            Ok(None) => assert!(false),
+            Ok(Some(_)) => assert!(false),
+            Err(InvalidOption::OptionContainsInvalidChar { option }) => {
+                assert_eq!(option, "f#o");
+            }
+            Err(_) => assert!(false),
+        }
+
+        assert_eq!(cmd.name(), "app");
+        assert_eq!(cmd.args(), &[] as &[&str]);
+        assert_eq!(cmd.has_opt("f#o"), false);
+        assert_eq!(cmd.opt_arg("f#o"), None);
     }
 }

--- a/src/parse/parse.rs
+++ b/src/parse/parse.rs
@@ -74,19 +74,8 @@ impl<'b, 'a> Cmd<'a> {
     /// This method creates and returns a new [Cmd] instance that holds the command line arguments
     /// starting from the first command argument.
     ///
-    /// This method divides command line arguments into options and command arguments based on
-    /// simple rules that are almost the same as POSIX & GNU:
-    /// arguments staring with `-` or `--` are treated as options, and others are treated as command
-    /// arguments.
-    /// If an `=` is found within an option, the part before the `=` is treated as the option name,
-    /// and the part after the `=` is treated as the option argument.
-    /// Options starting with `--` are long options and option starting with `-` are short options.
-    /// Multiple short options can be concatenated into a single command line argument.
-    /// If an argument is exactly `--`, all subsequent arguments are treated as command arguments.
-    ///
-    /// Since the results of parsing are stored into this `Cmd` instance, this method returns a
-    /// [Result] which contains an unit value (`()`) if succeeding, or a `errors::InvalidOption`
-    /// if failing.
+    /// This method parses command line arguments in the same way as the [Cmd::parse] method, except
+    /// that it only parses the command line arguments before the first command argument.
     ///
     /// ```rust
     /// use cliargs::Cmd;

--- a/src/parse/parse_for.rs
+++ b/src/parse/parse_for.rs
@@ -93,6 +93,7 @@ impl<'b> Cmd<'_> {
     /// let mut my_options = MyOptions::with_defaults();
     ///
     /// let mut cmd = Cmd::with_strings(vec![ /* ... */ ]);
+    ///
     /// match cmd.parse_for(&mut my_options) {
     ///     Ok(_) => { /* ... */ },
     ///     Err(InvalidOption::OptionContainsInvalidChar { option }) => { /* ... */ },
@@ -121,37 +122,8 @@ impl<'b> Cmd<'_> {
     /// This method creates and returns a new [Cmd] instance that holds the command line arguments
     /// starting from the first command argument.
     ///
-    /// Within this method, a vector of [OptCfg] is made from the fields of the option store.
-    /// This [OptCfg] vector is set to the public field `cfgs` of the [Cmd] instance.
-    /// If you want to access this option configurations, get them from this field.
-    ///
-    /// An option configuration corresponding to each field of an option store is determined by
-    /// its type and `opt` field attribute.
-    /// If the type is bool, the option takes no argument.
-    /// If the type is integer, floating point number or string, the option can takes single option
-    /// argument, therefore it can appear once in command line arguments.
-    /// If the type is a vector, the option can takes multiple option arguments, therefore it can
-    /// appear multiple times in command line arguments.
-    ///
-    /// A `opt` field attribute can have the following pairs of name and value: one is `cfg` to
-    /// specify `names` and `defaults` fields of [OptCfg] struct, another is `desc` to specify
-    /// `desc` field, and yet another is `arg` to specify `arg_in_help` field.
-    ///
-    /// The format of `cfg` is like `cfg="f,foo=123"`.
-    /// The left side of the equal sign is the option name(s), and the right side is the default
-    /// value(s).
-    /// If there is no equal sign, it is determined that only the option name is specified.
-    /// If you want to specify multiple option names, separate them with commas.
-    /// If you want to specify multiple default values, separate them with commas and round them
-    /// with square brackets, like `[1,2,3]`.
-    /// If you want to use your favorite carachter as a separator, you can use it by putting it on
-    /// the left side of the open square bracket, like `/[1/2/3]`.
-    ///
-    /// NOTE: A default value of empty string array option in a field attribute is `[]`, like
-    /// `#[opt(cfg="=[]")]`, but it doesn't represent an array which contains only one empty
-    /// string.
-    /// If you want to specify an array which contains only one emtpy string, write nothing after
-    /// `=` symbol, like `#[opt(cfg="=")]`.
+    /// This method parses command line arguments in the same way as the [Cmd::parse_for] method,
+    /// except that it only parses the command line arguments before the first command argument.
     ///
     /// ```
     /// use cliargs::Cmd;
@@ -167,6 +139,7 @@ impl<'b> Cmd<'_> {
     /// let mut my_options = MyOptions::with_defaults();
     ///
     /// let mut cmd = Cmd::with_strings(vec![ /* ... */ ]);
+    ///
     /// match cmd.parse_until_sub_cmd_for(&mut my_options) {
     ///     Ok(Some(mut sub_cmd)) => {
     ///         let sub_cmd_name = sub_cmd.name();

--- a/src/parse/parse_with.rs
+++ b/src/parse/parse_with.rs
@@ -71,19 +71,8 @@ impl<'b, 'a> Cmd<'a> {
     /// This method creates and returns a new [Cmd] instance that holds the command line arguments
     /// starting from the first command argument.
     ///
-    /// This method divides command line arguments to command arguments and options.
-    /// And an option consists of a name and an option argument.
-    /// Options are divided to long format options and short format options.
-    /// About long/short format options, since they are same with `parse` method, see the comment
-    /// of that method.
-    ///
-    /// This method allows only options declared in option configurations, basically.
-    /// An option configuration has fields: `store_key`, `names`, `has_arg`, `is_array`,
-    /// `defaults`, `desc`, `arg_in_help`, and `validator`.
-    ///
-    /// The ownership of the vector of option configurations which is passed as an argument of
-    /// this method is moved to this method and set to the public field `cfgs` of [Cmd] instance.
-    /// If you want to access the option configurations after parsing, get them from this field.
+    /// This method parses command line arguments in the same way as the [Cmd::parse_with] method,
+    /// except that it only parses the command line arguments before the first command argument.
     ///
     /// ```
     /// use cliargs::{Cmd, OptCfg};

--- a/tests/parse_for_test.rs
+++ b/tests/parse_for_test.rs
@@ -63,13 +63,12 @@ mod tests_of_parse_for {
 }
 
 mod tests_of_parse_until_sub_cmd_for {
-    use cliargs::validators::*;
     use cliargs::Cmd;
 
     #[derive(cliargs::OptStore)]
     struct Options1 {
         #[opt(cfg = "foo-bar")]
-        fooBar: u32,
+        foo_bar: u32,
         v: bool,
     }
 
@@ -99,9 +98,9 @@ mod tests_of_parse_until_sub_cmd_for {
 
             assert_eq!(cmd.name(), "app");
             assert_eq!(cmd.args(), &[] as &[&str]);
-            assert_eq!(cmd.has_opt("fooBar"), true);
-            assert_eq!(cmd.opt_arg("fooBar"), Some("123"));
-            assert_eq!(cmd.opt_args("fooBar"), Some(&["123"] as &[&str]));
+            assert_eq!(cmd.has_opt("foo_bar"), true);
+            assert_eq!(cmd.opt_arg("foo_bar"), Some("123"));
+            assert_eq!(cmd.opt_args("foo_bar"), Some(&["123"] as &[&str]));
             assert_eq!(cmd.has_opt("v"), true);
             assert_eq!(cmd.opt_arg("v"), None);
             assert_eq!(cmd.opt_args("v"), Some(&[] as &[&str]));
@@ -125,7 +124,7 @@ mod tests_of_parse_until_sub_cmd_for {
             assert!(false);
         }
 
-        assert_eq!(options1.fooBar, 123);
+        assert_eq!(options1.foo_bar, 123);
         assert_eq!(options1.v, true);
         assert_eq!(options2.qux, true);
         assert_eq!(options2.q, "ABC");

--- a/tests/parse_test.rs
+++ b/tests/parse_test.rs
@@ -67,6 +67,47 @@ mod tests_of_parse {
     }
 }
 
+mod tests_of_parse_until_sub_cmd {
+    use cliargs;
+
+    #[test]
+    fn it_should_parse_command_line_arguments_containing_subcommand() {
+        let mut cmd = cliargs::Cmd::with_strings([
+            "/path/to/app".to_string(),
+            "--foo-bar=123".to_string(),
+            "-v".to_string(),
+            "baz".to_string(),
+            "--qux".to_string(),
+            "corge".to_string(),
+            "-q=ABC".to_string(),
+        ]);
+
+        if let Some(mut sub_cmd) = cmd.parse_until_sub_cmd().unwrap() {
+            let _ = sub_cmd.parse().unwrap();
+
+            assert_eq!(cmd.name(), "app");
+            assert_eq!(cmd.args(), &[] as &[&str]);
+            assert_eq!(cmd.has_opt("foo-bar"), true);
+            assert_eq!(cmd.opt_arg("foo-bar"), Some("123"));
+            assert_eq!(cmd.opt_args("foo-bar"), Some(&["123"] as &[&str]));
+            assert_eq!(cmd.has_opt("v"), true);
+            assert_eq!(cmd.opt_arg("v"), None);
+            assert_eq!(cmd.opt_args("v"), Some(&[] as &[&str]));
+
+            assert_eq!(sub_cmd.name(), "baz");
+            assert_eq!(sub_cmd.args(), &["corge"]);
+            assert_eq!(sub_cmd.has_opt("qux"), true);
+            assert_eq!(sub_cmd.opt_arg("qux"), None);
+            assert_eq!(sub_cmd.opt_args("qux"), Some(&[] as &[&str]));
+            assert_eq!(sub_cmd.has_opt("q"), true);
+            assert_eq!(sub_cmd.opt_arg("q"), Some("ABC"));
+            assert_eq!(sub_cmd.opt_args("q"), Some(&["ABC"] as &[&str]));
+        } else {
+            assert!(false);
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests_of_errors {
     use cliargs;


### PR DESCRIPTION
This PR adds new methods of `Cmd`: `parse_until_sub_cmd`, `parse_until_sub_cmd_with`, and `parse_until_sub_cmd_for` for supportint sub command.

The above methods parses command line arguments and stops parsing before first command argument, then returns a new `Cmd` instances which holds command line arguments from first command argument.