### PR TITLE
update!: changed parameter type of OptCfg::with

### DIFF
--- a/src/help/mod.rs
+++ b/src/help/mod.rs
@@ -817,7 +817,7 @@ mod tests_of_help {
         use crate::OptCfgParam::*;
 
         let mut help = Help::new();
-        help.add_opts(&[OptCfg::with(&[
+        help.add_opts(&[OptCfg::with([
             names(&["foo-bar"]),
             desc("This is a description of option."),
         ])]);
@@ -841,7 +841,7 @@ mod tests_of_help {
         let cols = linebreak::term_cols();
 
         let mut help = Help::new();
-        help.add_opts(&[OptCfg::with(&[
+        help.add_opts(&[OptCfg::with([
             names(&["foo-bar"]),
             desc(&("a".repeat(cols - 11) + " bcdef")),
         ])]);
@@ -869,7 +869,7 @@ mod tests_of_help {
 
         let mut help = Help::with_margins(4, 2);
 
-        help.add_opts(&[OptCfg::with(&[
+        help.add_opts(&[OptCfg::with([
             names(&["foo-bar"]),
             desc(&("a".repeat(cols - 11 - 4 - 2) + " " + &"b".repeat(cols - 11 - 4 - 2) + "ccc")),
         ])]);
@@ -904,7 +904,7 @@ mod tests_of_help {
         let mut help = Help::new();
 
         help.add_opts_with_margins(
-            &[OptCfg::with(&[
+            &[OptCfg::with([
                 names(&["foo-bar"]),
                 desc(
                     &("a".repeat(cols - 11 - 5 - 4) + " " + &"b".repeat(cols - 11 - 5 - 4) + "ccc"),
@@ -944,7 +944,7 @@ mod tests_of_help {
         let mut help = Help::with_margins(4, 2);
 
         help.add_opts_with_margins(
-            &[OptCfg::with(&[
+            &[OptCfg::with([
                 names(&["foo-bar"]),
                 desc(
                     &("a".repeat(cols - 11 - 5 - 4) + " " + &"b".repeat(cols - 11 - 5 - 4) + "ccc"),
@@ -983,7 +983,7 @@ mod tests_of_help {
 
         let mut help = Help::new();
         help.add_opts_with_indent(
-            &[OptCfg::with(&[
+            &[OptCfg::with([
                 names(&["foo-bar"]),
                 desc(&("a".repeat(cols - 12) + " " + &"b".repeat(cols - 12) + "ccc")),
             ])],
@@ -1016,7 +1016,7 @@ mod tests_of_help {
 
         let mut help = Help::new();
         help.add_opts_with_indent(
-            &[OptCfg::with(&[
+            &[OptCfg::with([
                 names(&["foo-bar"]),
                 desc(&("a".repeat(cols))),
             ])],
@@ -1046,13 +1046,13 @@ mod tests_of_help {
 
         let mut help = Help::new();
         help.add_opts(&[
-            OptCfg::with(&[
+            OptCfg::with([
                 names(&["foo-bar", "f"]),
                 has_arg(true),
                 desc(&("a".repeat(cols - 22) + " " + &"b".repeat(cols - 22) + "ccc")),
                 arg_in_help("<text>"),
             ]),
-            OptCfg::with(&[
+            OptCfg::with([
                 names(&["baz", "b"]),
                 desc(&("d".repeat(cols - 22) + " " + &"e".repeat(cols - 22) + "fff")),
             ]),
@@ -1094,8 +1094,8 @@ mod tests_of_help {
 
         let mut help = Help::new();
         help.add_opts(&[
-            OptCfg::with(&[names(&["foo-bar"]), desc("description")]),
-            OptCfg::with(&[names(&["*"]), desc("any option")]),
+            OptCfg::with([names(&["foo-bar"]), desc("description")]),
+            OptCfg::with([names(&["*"]), desc("any option")]),
         ]);
 
         let mut iter = help.iter();
@@ -1113,8 +1113,8 @@ mod tests_of_help {
 
         let mut help = Help::new();
         help.add_opts(&[
-            OptCfg::with(&[store_key("foo"), desc("description")]),
-            OptCfg::with(&[store_key("*"), desc("any option")]),
+            OptCfg::with([store_key("foo"), desc("description")]),
+            OptCfg::with([store_key("*"), desc("any option")]),
         ]);
 
         let mut iter = help.iter();
@@ -1132,8 +1132,8 @@ mod tests_of_help {
 
         let mut help = Help::new();
         help.add_opts(&[
-            OptCfg::with(&[names(&["foo-bar"]), desc("description")]),
-            OptCfg::with(&[names(&["*"]), desc("any option")]),
+            OptCfg::with([names(&["foo-bar"]), desc("description")]),
+            OptCfg::with([names(&["*"]), desc("any option")]),
         ]);
 
         let mut iter = help.iter();
@@ -1154,8 +1154,8 @@ mod tests_of_help {
         let mut help = Help::new();
         help.add_opts_with_indent(
             &[
-                OptCfg::with(&[names(&["foo-bar"]), desc("description")]),
-                OptCfg::with(&[names(&["baz"]), desc("description")]),
+                OptCfg::with([names(&["foo-bar"]), desc("description")]),
+                OptCfg::with([names(&["baz"]), desc("description")]),
             ],
             cols + 1,
         );
@@ -1178,8 +1178,8 @@ mod tests_of_help {
         let mut help = Help::new();
         help.add_opts_with_margins(
             &[
-                OptCfg::with(&[names(&["foo-bar"]), desc("description")]),
-                OptCfg::with(&[names(&["baz"]), desc("description")]),
+                OptCfg::with([names(&["foo-bar"]), desc("description")]),
+                OptCfg::with([names(&["baz"]), desc("description")]),
             ],
             cols - 1,
             1,
@@ -1200,8 +1200,8 @@ mod tests_of_help {
 
         let mut help = Help::new();
         help.add_opts(&[
-            OptCfg::with(&[names(&["", "f", "foo-bar", "", ""]), desc("description")]),
-            OptCfg::with(&[names(&["b", "", "z", "baz"]), desc("description")]),
+            OptCfg::with([names(&["", "f", "foo-bar", "", ""]), desc("description")]),
+            OptCfg::with([names(&["b", "", "z", "baz"]), desc("description")]),
         ]);
 
         let mut iter = help.iter();

--- a/src/help/opts.rs
+++ b/src/help/opts.rs
@@ -203,7 +203,7 @@ mod tests_of_make_opt_title {
 
     #[test]
     fn test_when_cfg_has_only_one_long_name() {
-        let cfg = OptCfg::with(&[names(&["foo-bar"])]);
+        let cfg = OptCfg::with([names(&["foo-bar"])]);
         let (indent, title) = make_opt_title(&cfg);
         assert_eq!(indent, 0);
         assert_eq!(title, "--foo-bar");
@@ -211,7 +211,7 @@ mod tests_of_make_opt_title {
 
     #[test]
     fn test_when_cfg_has_only_one_short_name() {
-        let cfg = OptCfg::with(&[names(&["f"])]);
+        let cfg = OptCfg::with([names(&["f"])]);
         let (indent, title) = make_opt_title(&cfg);
         assert_eq!(indent, 0);
         assert_eq!(title, "-f");
@@ -219,7 +219,7 @@ mod tests_of_make_opt_title {
 
     #[test]
     fn test_when_cfg_has_multiple_names() {
-        let cfg = OptCfg::with(&[names(&["f", "b", "foo-bar"])]);
+        let cfg = OptCfg::with([names(&["f", "b", "foo-bar"])]);
         let (indent, title) = make_opt_title(&cfg);
         assert_eq!(indent, 0);
         assert_eq!(title, "-f, -b, --foo-bar");
@@ -227,7 +227,7 @@ mod tests_of_make_opt_title {
 
     #[test]
     fn test_when_cfg_has_no_name_but_store_key() {
-        let cfg = OptCfg::with(&[store_key("Foo_Bar")]);
+        let cfg = OptCfg::with([store_key("Foo_Bar")]);
         let (indent, title) = make_opt_title(&cfg);
         assert_eq!(indent, 0);
         assert_eq!(title, "--Foo_Bar");
@@ -235,12 +235,12 @@ mod tests_of_make_opt_title {
 
     #[test]
     fn test_when_cfg_names_contain_emtpy_name() {
-        let cfg = OptCfg::with(&[names(&["", "f"])]);
+        let cfg = OptCfg::with([names(&["", "f"])]);
         let (indent, title) = make_opt_title(&cfg);
         assert_eq!(indent, 4);
         assert_eq!(title, "-f");
 
-        let cfg = OptCfg::with(&[names(&["", "f", "", "b", ""])]);
+        let cfg = OptCfg::with([names(&["", "f", "", "b", ""])]);
         let (indent, title) = make_opt_title(&cfg);
         assert_eq!(indent, 4);
         assert_eq!(title, "-f,     -b");
@@ -248,7 +248,7 @@ mod tests_of_make_opt_title {
 
     #[test]
     fn test_when_cfg_names_are_all_empty_and_has_store_key() {
-        let cfg = OptCfg::with(&[store_key("FooBar"), names(&["", ""])]);
+        let cfg = OptCfg::with([store_key("FooBar"), names(&["", ""])]);
         let (indent, title) = make_opt_title(&cfg);
         assert_eq!(indent, 8);
         assert_eq!(title, "--FooBar");
@@ -262,7 +262,7 @@ mod tests_of_create_opts_help {
 
     #[test]
     fn test_when_cfg_has_only_one_long_name() {
-        let cfgs = vec![OptCfg::with(&[names(&["foo-bar"])])];
+        let cfgs = vec![OptCfg::with([names(&["foo-bar"])])];
 
         let mut indent = 0;
         let vec = create_opts_help(&cfgs, &mut indent);
@@ -276,7 +276,7 @@ mod tests_of_create_opts_help {
 
     #[test]
     fn test_when_cfg_has_only_one_long_name_and_desc() {
-        let cfgs = vec![OptCfg::with(&[
+        let cfgs = vec![OptCfg::with([
             names(&["foo-bar"]),
             desc("The description of foo-bar."),
         ])];
@@ -293,7 +293,7 @@ mod tests_of_create_opts_help {
 
     #[test]
     fn test_when_cfg_has_only_one_long_name_and_desc_and_arg_in_help() {
-        let cfgs = vec![OptCfg::with(&[
+        let cfgs = vec![OptCfg::with([
             names(&["foo-bar"]),
             desc("The description of foo-bar."),
             arg_in_help("<num>"),
@@ -311,7 +311,7 @@ mod tests_of_create_opts_help {
 
     #[test]
     fn test_when_cfg_has_only_one_short_name() {
-        let cfgs = vec![OptCfg::with(&[names(&["f"])])];
+        let cfgs = vec![OptCfg::with([names(&["f"])])];
 
         let mut indent = 0;
         let vec = create_opts_help(&cfgs, &mut indent);
@@ -325,10 +325,7 @@ mod tests_of_create_opts_help {
 
     #[test]
     fn test_when_cfg_has_only_one_short_name_and_desc() {
-        let cfgs = vec![OptCfg::with(&[
-            names(&["f"]),
-            desc("The description of f."),
-        ])];
+        let cfgs = vec![OptCfg::with([names(&["f"]), desc("The description of f.")])];
 
         let mut indent = 0;
         let vec = create_opts_help(&cfgs, &mut indent);
@@ -342,7 +339,7 @@ mod tests_of_create_opts_help {
 
     #[test]
     fn test_when_cfg_has_only_one_short_name_and_desc_and_arg_in_help() {
-        let cfgs = vec![OptCfg::with(&[
+        let cfgs = vec![OptCfg::with([
             names(&["f"]),
             desc("The description of f."),
             arg_in_help("<n>"),
@@ -360,7 +357,7 @@ mod tests_of_create_opts_help {
 
     #[test]
     fn test_when_indent_is_positive_and_longer_than_title() {
-        let cfgs = vec![OptCfg::with(&[
+        let cfgs = vec![OptCfg::with([
             names(&["foo-bar"]),
             desc("The description of foo-bar."),
             arg_in_help("<num>"),
@@ -378,7 +375,7 @@ mod tests_of_create_opts_help {
 
     #[test]
     fn test_when_indent_is_positive_and_shorter_than_title() {
-        let cfgs = vec![OptCfg::with(&[
+        let cfgs = vec![OptCfg::with([
             names(&["foo-bar"]),
             desc("The description of foo-bar."),
             arg_in_help("<num>"),
@@ -411,7 +408,7 @@ mod tests_of_create_opts_help {
 
     #[test]
     fn test_when_names_contains_empty_strings() {
-        let cfgs = vec![OptCfg::with(&[
+        let cfgs = vec![OptCfg::with([
             names(&["", "", "f", "", "foo-bar", ""]),
             desc("The description of foo-bar."),
             arg_in_help("<num>"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,7 +131,7 @@
 //! If you want to prioritize the output of short option name first in the help
 //! text, like `-f, --foo-bar`, but use the long option name as the key in the
 //! option map, write `store_key` and `names` fields as follows:
-//! `OptCfg::with(&[store_key("foo-bar"), names(&["f", "foo-bar"])])`.
+//! `OptCfg::with([store_key("foo-bar"), names(&["f", "foo-bar"])])`.
 //!
 //! `has_arg` field indicates the option requires one or more values.
 //! `is_array` field indicates the option can have multiple values.
@@ -167,7 +167,7 @@
 //!         arg_in_help: "<num>".to_string(),
 //!         validator: validate_number::<u64>,
 //!     },
-//!     OptCfg::with(&[
+//!     OptCfg::with([
 //!         names(&["baz", "z"]),
 //!         has_arg(true),
 //!         defaults(&["1"]),
@@ -900,8 +900,8 @@ mod tests_of_cmd {
             }
 
             let cfgs = vec![
-                OptCfg::with(&[names(&["foo"])]),
-                OptCfg::with(&[names(&["bar"]), has_arg(true), is_array(true)]),
+                OptCfg::with([names(&["foo"])]),
+                OptCfg::with([names(&["bar"]), has_arg(true), is_array(true)]),
             ];
 
             let mut cmd = Cmd::with_strings([
@@ -923,8 +923,8 @@ mod tests_of_cmd {
         fn should_move_by_returning() {
             fn move_cmd() -> Cmd<'static> {
                 let cfgs = vec![
-                    OptCfg::with(&[names(&["foo"])]),
-                    OptCfg::with(&[names(&["bar"]), has_arg(true), is_array(true)]),
+                    OptCfg::with([names(&["foo"])]),
+                    OptCfg::with([names(&["bar"]), has_arg(true), is_array(true)]),
                 ];
 
                 let mut cmd = Cmd::with_strings([
@@ -982,8 +982,8 @@ mod tests_of_cmd {
         fn should_move_by_mem_replace() {
             fn move_cmd() -> Cmd<'static> {
                 let cfgs = vec![
-                    OptCfg::with(&[names(&["foo"])]),
-                    OptCfg::with(&[names(&["bar"]), has_arg(true), is_array(true)]),
+                    OptCfg::with([names(&["foo"])]),
+                    OptCfg::with([names(&["bar"]), has_arg(true), is_array(true)]),
                 ];
 
                 let mut cmd = Cmd::with_strings([
@@ -1044,8 +1044,8 @@ mod tests_of_cmd {
         fn should_move_by_mem_swap() {
             fn move_cmd() -> Cmd<'static> {
                 let cfgs = vec![
-                    OptCfg::with(&[names(&["foo"])]),
-                    OptCfg::with(&[names(&["bar"]), has_arg(true), is_array(true)]),
+                    OptCfg::with([names(&["foo"])]),
+                    OptCfg::with([names(&["bar"]), has_arg(true), is_array(true)]),
                 ];
 
                 let mut cmd = Cmd::with_strings([

--- a/src/parse/parse_with.rs
+++ b/src/parse/parse_with.rs
@@ -33,11 +33,11 @@ impl<'b, 'a> Cmd<'a> {
     ///
     /// let mut cmd = Cmd::with_strings(vec![ /* ... */ ]);
     /// let opt_cfgs = vec![
-    ///     OptCfg::with(&[
+    ///     OptCfg::with([
     ///         names(&["foo-bar"]),
     ///         desc("This is description of foo-bar."),
     ///     ]),
-    ///     OptCfg::with(&[
+    ///     OptCfg::with([
     ///         names(&["baz", "z"]),
     ///         has_arg(true),
     ///         defaults(&["1"]),
@@ -82,11 +82,11 @@ impl<'b, 'a> Cmd<'a> {
     ///
     /// let mut cmd = Cmd::with_strings(vec![ /* ... */ ]);
     /// let opt_cfgs = vec![
-    ///     OptCfg::with(&[
+    ///     OptCfg::with([
     ///         names(&["foo-bar"]),
     ///         desc("This is description of foo-bar."),
     ///     ]),
-    ///     OptCfg::with(&[
+    ///     OptCfg::with([
     ///         names(&["baz", "z"]),
     ///         has_arg(true),
     ///         defaults(&["1"]),
@@ -458,7 +458,7 @@ mod tests_of_parse_with {
 
     #[test]
     fn one_cfg_and_zero_opt() {
-        let opt_cfgs = vec![OptCfg::with(&[names(&["foo-bar"])])];
+        let opt_cfgs = vec![OptCfg::with([names(&["foo-bar"])])];
 
         let mut cmd = Cmd::with_strings(["path/to/app".to_string()]);
 
@@ -488,7 +488,7 @@ mod tests_of_parse_with {
 
     #[test]
     fn one_cfg_and_one_cmd_arg() {
-        let opt_cfgs = vec![OptCfg::with(&[names(&["foo-bar"])])];
+        let opt_cfgs = vec![OptCfg::with([names(&["foo-bar"])])];
 
         let mut cmd = Cmd::with_strings(["path/to/app".to_string(), "foo-bar".to_string()]);
 
@@ -518,7 +518,7 @@ mod tests_of_parse_with {
 
     #[test]
     fn one_cfg_and_one_long_opt() {
-        let opt_cfgs = vec![OptCfg::with(&[names(&["foo-bar"])])];
+        let opt_cfgs = vec![OptCfg::with([names(&["foo-bar"])])];
 
         let mut cmd = Cmd::with_strings(["path/to/app".to_string(), "--foo-bar".to_string()]);
 
@@ -548,7 +548,7 @@ mod tests_of_parse_with {
 
     #[test]
     fn one_cfg_and_one_short_opt() {
-        let opt_cfgs = vec![OptCfg::with(&[names(&["f"])])];
+        let opt_cfgs = vec![OptCfg::with([names(&["f"])])];
 
         let mut cmd = Cmd::with_strings(["app".to_string(), "-f".to_string()]);
 
@@ -578,7 +578,7 @@ mod tests_of_parse_with {
 
     #[test]
     fn one_cfg_and_one_different_long_opt() {
-        let opt_cfgs = vec![OptCfg::with(&[names(&["foo-bar"])])];
+        let opt_cfgs = vec![OptCfg::with([names(&["foo-bar"])])];
 
         let mut cmd = Cmd::with_strings(["path/to/app".to_string(), "--bar-foo".to_string()]);
 
@@ -615,7 +615,7 @@ mod tests_of_parse_with {
 
     #[test]
     fn one_cfg_and_one_different_short_opt() {
-        let opt_cfgs = vec![OptCfg::with(&[names(&["f"])])];
+        let opt_cfgs = vec![OptCfg::with([names(&["f"])])];
 
         let mut cmd = Cmd::with_strings(["app".to_string(), "-b".to_string()]);
 
@@ -653,8 +653,8 @@ mod tests_of_parse_with {
     #[test]
     fn any_opt_cfg_and_one_different_long_opt() {
         let opt_cfgs = vec![
-            OptCfg::with(&[names(&["foo-bar"])]),
-            OptCfg::with(&[names(&["*"])]),
+            OptCfg::with([names(&["foo-bar"])]),
+            OptCfg::with([names(&["*"])]),
         ];
 
         let mut cmd = Cmd::with_strings(["path/to/app".to_string(), "--bar-foo".to_string()]);
@@ -696,10 +696,7 @@ mod tests_of_parse_with {
 
     #[test]
     fn any_opt_cfg_and_one_different_short_opt() {
-        let opt_cfgs = vec![
-            OptCfg::with(&[names(&["f"])]),
-            OptCfg::with(&[names(&["*"])]),
-        ];
+        let opt_cfgs = vec![OptCfg::with([names(&["f"])]), OptCfg::with([names(&["*"])])];
 
         let mut cmd = Cmd::with_strings(["app".to_string(), "-b".to_string()]);
 
@@ -740,7 +737,7 @@ mod tests_of_parse_with {
 
     #[test]
     fn one_cfg_requires_arg_and_one_long_opt_has_arg() {
-        let opt_cfgs = vec![OptCfg::with(&[names(&["foo-bar"]), has_arg(true)])];
+        let opt_cfgs = vec![OptCfg::with([names(&["foo-bar"]), has_arg(true)])];
 
         let mut cmd = Cmd::with_strings([
             "app".to_string(),
@@ -771,7 +768,7 @@ mod tests_of_parse_with {
 
     #[test]
     fn one_cfg_requires_arg_and_one_short_opt_has_arg() {
-        let opt_cfgs = vec![OptCfg::with(&[names(&["f"]), has_arg(true)])];
+        let opt_cfgs = vec![OptCfg::with([names(&["f"]), has_arg(true)])];
 
         let mut cmd = Cmd::with_strings(["app".to_string(), "-f".to_string(), "ABC".to_string()]);
 
@@ -798,7 +795,7 @@ mod tests_of_parse_with {
 
     #[test]
     fn one_cfg_requires_arg_but_one_long_opt_has_no_arg() {
-        let opt_cfgs = vec![OptCfg::with(&[names(&["foo-bar"]), has_arg(true)])];
+        let opt_cfgs = vec![OptCfg::with([names(&["foo-bar"]), has_arg(true)])];
 
         let mut cmd = Cmd::with_strings(["app".to_string(), "--foo-bar".to_string()]);
 
@@ -839,7 +836,7 @@ mod tests_of_parse_with {
 
     #[test]
     fn one_cfg_requires_arg_but_one_short_oopt_has_no_arg() {
-        let opt_cfgs = vec![OptCfg::with(&[names(&["f"]), has_arg(true)])];
+        let opt_cfgs = vec![OptCfg::with([names(&["f"]), has_arg(true)])];
 
         let mut cmd = Cmd::with_strings(["app".to_string(), "-f".to_string()]);
 
@@ -879,7 +876,7 @@ mod tests_of_parse_with {
 
     #[test]
     fn one_cfg_requires_no_arg_but_one_long_opt_has_arg() {
-        let opt_cfgs = vec![OptCfg::with(&[names(&["foo-bar"])])];
+        let opt_cfgs = vec![OptCfg::with([names(&["foo-bar"])])];
 
         let mut cmd = Cmd::with_strings([
             "app".to_string(),
@@ -908,7 +905,7 @@ mod tests_of_parse_with {
         assert_eq!(cmd.cfgs[0].desc, "".to_string());
         assert_eq!(cmd.cfgs[0].arg_in_help, "".to_string());
 
-        let opt_cfgs = vec![OptCfg::with(&[names(&["foo-bar"])])];
+        let opt_cfgs = vec![OptCfg::with([names(&["foo-bar"])])];
 
         let mut cmd = Cmd::with_strings(["app".to_string(), "--foo-bar=ABC".to_string()]);
 
@@ -945,7 +942,7 @@ mod tests_of_parse_with {
         assert_eq!(cmd.cfgs[0].desc, "".to_string());
         assert_eq!(cmd.cfgs[0].arg_in_help, "".to_string());
 
-        let opt_cfgs = vec![OptCfg::with(&[names(&["foo-bar"])])];
+        let opt_cfgs = vec![OptCfg::with([names(&["foo-bar"])])];
 
         let mut cmd =
             Cmd::with_strings(["app".to_string(), "--foo-bar".to_string(), "".to_string()]);
@@ -971,7 +968,7 @@ mod tests_of_parse_with {
         assert_eq!(cmd.cfgs[0].desc, "".to_string());
         assert_eq!(cmd.cfgs[0].arg_in_help, "".to_string());
 
-        let opt_cfgs = vec![OptCfg::with(&[names(&["foo-bar"])])];
+        let opt_cfgs = vec![OptCfg::with([names(&["foo-bar"])])];
 
         let mut cmd = Cmd::with_strings(["app".to_string(), "--foo-bar=".to_string()]);
 
@@ -1011,7 +1008,7 @@ mod tests_of_parse_with {
 
     #[test]
     fn one_cfg_requires_no_arg_but_one_short_opt_has_arg() {
-        let opt_cfgs = vec![OptCfg::with(&[names(&["f"])])];
+        let opt_cfgs = vec![OptCfg::with([names(&["f"])])];
 
         let mut cmd = Cmd::with_strings(["app".to_string(), "-f".to_string(), "ABC".to_string()]);
 
@@ -1036,7 +1033,7 @@ mod tests_of_parse_with {
         assert_eq!(cmd.cfgs[0].desc, "".to_string());
         assert_eq!(cmd.cfgs[0].arg_in_help, "".to_string());
 
-        let opt_cfgs = vec![OptCfg::with(&[names(&["f"])])];
+        let opt_cfgs = vec![OptCfg::with([names(&["f"])])];
 
         let mut cmd = Cmd::with_strings(["app".to_string(), "-f=ABC".to_string()]);
 
@@ -1073,7 +1070,7 @@ mod tests_of_parse_with {
         assert_eq!(cmd.cfgs[0].desc, "".to_string());
         assert_eq!(cmd.cfgs[0].arg_in_help, "".to_string());
 
-        let opt_cfgs = vec![OptCfg::with(&[names(&["f"])])];
+        let opt_cfgs = vec![OptCfg::with([names(&["f"])])];
 
         let mut cmd = Cmd::with_strings(["app".to_string(), "-f".to_string(), "".to_string()]);
 
@@ -1098,7 +1095,7 @@ mod tests_of_parse_with {
         assert_eq!(cmd.cfgs[0].desc, "".to_string());
         assert_eq!(cmd.cfgs[0].arg_in_help, "".to_string());
 
-        let opt_cfgs = vec![OptCfg::with(&[names(&["f"])])];
+        let opt_cfgs = vec![OptCfg::with([names(&["f"])])];
 
         let mut cmd = Cmd::with_strings(["app".to_string(), "-f=".to_string()]);
 
@@ -1138,7 +1135,7 @@ mod tests_of_parse_with {
 
     #[test]
     fn one_cfg_requires_no_arg_but_is_array() {
-        let opt_cfgs = vec![OptCfg::with(&[
+        let opt_cfgs = vec![OptCfg::with([
             names(&["foo-bar"]),
             has_arg(false),
             is_array(true),
@@ -1184,8 +1181,8 @@ mod tests_of_parse_with {
     #[test]
     fn one_cfg_is_array_and_opt_has_no_arg() {
         let opt_cfgs = vec![
-            OptCfg::with(&[names(&["foo-bar"]), has_arg(true), is_array(true)]),
-            OptCfg::with(&[names(&["f"]), has_arg(true), is_array(true)]),
+            OptCfg::with([names(&["foo-bar"]), has_arg(true), is_array(true)]),
+            OptCfg::with([names(&["f"]), has_arg(true), is_array(true)]),
         ];
 
         let mut cmd = Cmd::with_strings(["app".to_string(), "--foo-bar".to_string()]);
@@ -1232,8 +1229,8 @@ mod tests_of_parse_with {
         assert_eq!(cmd.cfgs[1].arg_in_help, "".to_string());
 
         let opt_cfgs = vec![
-            OptCfg::with(&[names(&["foo-bar"]), has_arg(true), is_array(true)]),
-            OptCfg::with(&[names(&["f"]), has_arg(true), is_array(true)]),
+            OptCfg::with([names(&["foo-bar"]), has_arg(true), is_array(true)]),
+            OptCfg::with([names(&["f"]), has_arg(true), is_array(true)]),
         ];
 
         let mut cmd = Cmd::with_strings(["app".to_string(), "-f".to_string()]);
@@ -1283,8 +1280,8 @@ mod tests_of_parse_with {
     #[test]
     fn one_cfg_is_array_and_opt_has_one_arg() {
         let opt_cfgs = vec![
-            OptCfg::with(&[names(&["foo-bar"]), has_arg(true), is_array(true)]),
-            OptCfg::with(&[names(&["f"]), has_arg(true), is_array(true)]),
+            OptCfg::with([names(&["foo-bar"]), has_arg(true), is_array(true)]),
+            OptCfg::with([names(&["f"]), has_arg(true), is_array(true)]),
         ];
 
         let mut cmd = Cmd::with_strings([
@@ -1330,8 +1327,8 @@ mod tests_of_parse_with {
     #[test]
     fn one_cfg_is_array_and_opt_has_multiple_args() {
         let opt_cfgs = vec![
-            OptCfg::with(&[names(&["foo-bar"]), has_arg(true), is_array(true)]),
-            OptCfg::with(&[names(&["f"]), has_arg(true), is_array(true)]),
+            OptCfg::with([names(&["foo-bar"]), has_arg(true), is_array(true)]),
+            OptCfg::with([names(&["f"]), has_arg(true), is_array(true)]),
         ];
 
         let mut cmd = Cmd::with_strings([
@@ -1380,7 +1377,7 @@ mod tests_of_parse_with {
 
     #[test]
     fn one_cfg_has_name_and_aliase_and_arg_matches_them() {
-        let opt_cfgs = vec![OptCfg::with(&[
+        let opt_cfgs = vec![OptCfg::with([
             names(&["foo-bar", "f"]),
             has_arg(true),
             is_array(true),
@@ -1425,8 +1422,8 @@ mod tests_of_parse_with {
     #[test]
     fn one_cfg_is_not_array_but_opts_are_multiple() {
         let opt_cfgs = vec![
-            OptCfg::with(&[names(&["foo-bar"]), has_arg(true)]),
-            OptCfg::with(&[names(&["f"]), has_arg(true)]),
+            OptCfg::with([names(&["foo-bar"]), has_arg(true)]),
+            OptCfg::with([names(&["f"]), has_arg(true)]),
         ];
 
         let mut cmd = Cmd::with_strings([
@@ -1465,8 +1462,8 @@ mod tests_of_parse_with {
         assert_eq!(cmd.args(), &[] as &[&str]);
 
         let opt_cfgs = vec![
-            OptCfg::with(&[names(&["foo-bar"]), has_arg(true)]),
-            OptCfg::with(&[names(&["f"]), has_arg(true)]),
+            OptCfg::with([names(&["foo-bar"]), has_arg(true)]),
+            OptCfg::with([names(&["f"]), has_arg(true)]),
         ];
 
         let mut cmd = Cmd::with_strings([
@@ -1524,8 +1521,8 @@ mod tests_of_parse_with {
     #[test]
     fn specify_defaults() {
         let opt_cfgs = vec![
-            OptCfg::with(&[names(&["bar"]), has_arg(true), defaults(&["A"])]),
-            OptCfg::with(&[
+            OptCfg::with([names(&["bar"]), has_arg(true), defaults(&["A"])]),
+            OptCfg::with([
                 names(&["baz"]),
                 has_arg(true),
                 is_array(true),
@@ -1572,7 +1569,7 @@ mod tests_of_parse_with {
 
     #[test]
     fn one_cfg_requires_no_arg_but_has_defaults() {
-        let opt_cfgs = vec![OptCfg::with(&[names(&["foo-bar"]), defaults(&["A"])])];
+        let opt_cfgs = vec![OptCfg::with([names(&["foo-bar"]), defaults(&["A"])])];
 
         let mut cmd = Cmd::with_strings(["app".to_string()]);
 
@@ -1614,10 +1611,10 @@ mod tests_of_parse_with {
     #[test]
     fn multiple_args() {
         let opt_cfgs = vec![
-            OptCfg::with(&[names(&["foo-bar"])]),
-            OptCfg::with(&[names(&["baz", "z"]), has_arg(true), is_array(true)]),
-            OptCfg::with(&[names(&["corge"]), has_arg(true), defaults(&["99"])]),
-            OptCfg::with(&[names(&["*"])]),
+            OptCfg::with([names(&["foo-bar"])]),
+            OptCfg::with([names(&["baz", "z"]), has_arg(true), is_array(true)]),
+            OptCfg::with([names(&["corge"]), has_arg(true), defaults(&["99"])]),
+            OptCfg::with([names(&["*"])]),
         ];
 
         let mut cmd = Cmd::with_strings([
@@ -1685,7 +1682,7 @@ mod tests_of_parse_with {
 
     #[test]
     fn parse_all_args_even_if_error() {
-        let opt_cfgs = vec![OptCfg::with(&[names(&["foo", "f"])])];
+        let opt_cfgs = vec![OptCfg::with([names(&["foo", "f"])])];
 
         let mut cmd = Cmd::with_strings(["app".to_string(), "-ef".to_string(), "bar".to_string()]);
 
@@ -1725,8 +1722,8 @@ mod tests_of_parse_with {
     #[test]
     fn parse_all_args_even_if_short_option_value_is_error() {
         let opt_cfgs = vec![
-            OptCfg::with(&[names(&["e"])]),
-            OptCfg::with(&[names(&["foo", "f"])]),
+            OptCfg::with([names(&["e"])]),
+            OptCfg::with([names(&["foo", "f"])]),
         ];
 
         let mut cmd =
@@ -1779,8 +1776,8 @@ mod tests_of_parse_with {
     #[test]
     fn parse_all_args_even_if_long_option_value_is_error() {
         let opt_cfgs = vec![
-            OptCfg::with(&[names(&["e"])]),
-            OptCfg::with(&[names(&["foo", "f"])]),
+            OptCfg::with([names(&["e"])]),
+            OptCfg::with([names(&["foo", "f"])]),
         ];
 
         let mut cmd = Cmd::with_strings([
@@ -1836,10 +1833,7 @@ mod tests_of_parse_with {
 
     #[test]
     fn ignore_cfg_if_names_is_empty() {
-        let opt_cfgs = vec![
-            OptCfg::with(&[names(&[])]),
-            OptCfg::with(&[names(&["foo"])]),
-        ];
+        let opt_cfgs = vec![OptCfg::with([names(&[])]), OptCfg::with([names(&["foo"])])];
 
         let mut cmd =
             Cmd::with_strings(["app".to_string(), "--foo".to_string(), "bar".to_string()]);
@@ -1874,8 +1868,8 @@ mod tests_of_parse_with {
     #[test]
     fn option_name_is_duplicated() {
         let opt_cfgs = vec![
-            OptCfg::with(&[names(&["foo", "f"])]),
-            OptCfg::with(&[names(&["bar", "f"])]),
+            OptCfg::with([names(&["foo", "f"])]),
+            OptCfg::with([names(&["bar", "f"])]),
         ];
 
         let mut cmd =
@@ -1925,7 +1919,7 @@ mod tests_of_parse_with {
 
     #[test]
     fn use_store_key() {
-        let opt_cfgs = vec![OptCfg::with(&[store_key("FooBar"), names(&["f", "foo"])])];
+        let opt_cfgs = vec![OptCfg::with([store_key("FooBar"), names(&["f", "foo"])])];
 
         let mut cmd =
             Cmd::with_strings(["app".to_string(), "--foo".to_string(), "bar".to_string()]);
@@ -1956,7 +1950,7 @@ mod tests_of_parse_with {
 
     #[test]
     fn use_store_key_as_option_name_if_names_is_empty() {
-        let opt_cfgs = vec![OptCfg::with(&[store_key("FooBar")])];
+        let opt_cfgs = vec![OptCfg::with([store_key("FooBar")])];
 
         let mut cmd = Cmd::with_strings(["app".to_string(), "--FooBar".to_string()]);
 
@@ -1988,8 +1982,8 @@ mod tests_of_parse_with {
     #[test]
     fn store_key_is_duplicated() {
         let opt_cfgs = vec![
-            OptCfg::with(&[store_key("FooBar"), names(&["f", "foo"])]),
-            OptCfg::with(&[store_key("FooBar"), names(&["b", "bar"])]),
+            OptCfg::with([store_key("FooBar"), names(&["f", "foo"])]),
+            OptCfg::with([store_key("FooBar"), names(&["b", "bar"])]),
         ];
 
         let mut cmd =
@@ -2039,7 +2033,7 @@ mod tests_of_parse_with {
 
     #[test]
     fn accept_all_options_if_store_key_is_asterisk() {
-        let opt_cfgs = vec![OptCfg::with(&[store_key("*")])];
+        let opt_cfgs = vec![OptCfg::with([store_key("*")])];
 
         let mut cmd = Cmd::with_strings([
             "app".to_string(),
@@ -2072,13 +2066,13 @@ mod tests_of_parse_with {
     #[test]
     fn accept_unconfigured_option_even_if_it_matches_store_key() {
         let opt_cfgs = vec![
-            OptCfg::with(&[
+            OptCfg::with([
                 store_key("Bar"),
                 names(&["foo", "f"]),
                 has_arg(true),
                 is_array(true),
             ]),
-            OptCfg::with(&[store_key("*")]),
+            OptCfg::with([store_key("*")]),
         ];
 
         let mut cmd = Cmd::with_strings([
@@ -2128,9 +2122,9 @@ mod tests_of_parse_util_sub_cmd_with {
 
     #[test]
     fn get_sub_cmd() {
-        let opt_cfgs1 = vec![OptCfg::with(&[names(&["foo", "f"])])];
+        let opt_cfgs1 = vec![OptCfg::with([names(&["foo", "f"])])];
 
-        let opt_cfgs2 = vec![OptCfg::with(&[names(&["bar", "b"])])];
+        let opt_cfgs2 = vec![OptCfg::with([names(&["bar", "b"])])];
 
         let mut cmd = Cmd::with_strings([
             "app".to_string(),
@@ -2188,7 +2182,7 @@ mod tests_of_parse_util_sub_cmd_with {
 
     #[test]
     fn no_sub_cmd() {
-        let opt_cfgs = vec![OptCfg::with(&[names(&["foo", "f"])])];
+        let opt_cfgs = vec![OptCfg::with([names(&["foo", "f"])])];
 
         let mut cmd = Cmd::with_strings(["app".to_string(), "--foo".to_string()]);
 
@@ -2216,7 +2210,7 @@ mod tests_of_parse_util_sub_cmd_with {
 
     #[test]
     fn fail_to_parse() {
-        let opt_cfgs = vec![OptCfg::with(&[names(&["foo-bar"])])];
+        let opt_cfgs = vec![OptCfg::with([names(&["foo-bar"])])];
 
         let mut cmd = Cmd::with_strings(["path/to/app".to_string(), "--bar-foo".to_string()]);
 

--- a/tests/help_test.rs
+++ b/tests/help_test.rs
@@ -12,75 +12,75 @@ mod tests_of_print_help {
 
         help.add_opts_with_margins(
             &[
-                cliargs::OptCfg::with(&[
+                cliargs::OptCfg::with([
                     store_key("data"),
                     names(&["d", "data"]),
                     has_arg(true),
                     desc("HTTP POST data"),
                     arg_in_help("<data>"),
                 ]),
-                cliargs::OptCfg::with(&[
+                cliargs::OptCfg::with([
                     store_key("fail"),
                     names(&["f", "fail"]),
                     desc("Fail fast with no output on HTTP errors"),
                     arg_in_help("<data>"),
                 ]),
-                cliargs::OptCfg::with(&[
+                cliargs::OptCfg::with([
                     store_key("help"),
                     names(&["h", "help"]),
                     has_arg(true),
                     desc("Get help for commands"),
                     arg_in_help("<category>"),
                 ]),
-                cliargs::OptCfg::with(&[
+                cliargs::OptCfg::with([
                     store_key("include"),
                     names(&["i", "include"]),
                     desc("Include protocol response headers in the output"),
                 ]),
-                cliargs::OptCfg::with(&[
+                cliargs::OptCfg::with([
                     store_key("output"),
                     names(&["o", "output"]),
                     has_arg(true),
                     desc("Write to file instead of stdout"),
                     arg_in_help("<file>"),
                 ]),
-                cliargs::OptCfg::with(&[
+                cliargs::OptCfg::with([
                     store_key("remove_name"),
                     names(&["O", "remove-name"]),
                     desc("Write output to a file named as the remote file"),
                 ]),
-                cliargs::OptCfg::with(&[
+                cliargs::OptCfg::with([
                     store_key("silent"),
                     names(&["s", "silent"]),
                     desc("Silent mode"),
                 ]),
-                cliargs::OptCfg::with(&[
+                cliargs::OptCfg::with([
                     store_key("upload_file"),
                     names(&["T", "upload-file"]),
                     has_arg(true),
                     desc("Transfer local FILE to destination"),
                     arg_in_help("<file>"),
                 ]),
-                cliargs::OptCfg::with(&[
+                cliargs::OptCfg::with([
                     store_key("user"),
                     names(&["u", "user"]),
                     has_arg(true),
                     desc("Server user and password"),
                     arg_in_help("<user:password>"),
                 ]),
-                cliargs::OptCfg::with(&[
+                cliargs::OptCfg::with([
                     store_key("user_agent"),
                     names(&["A", "user-agent"]),
                     has_arg(true),
                     desc("Send User-Agent <name> to server"),
                     arg_in_help("<name>"),
                 ]),
-                cliargs::OptCfg::with(&[
+                cliargs::OptCfg::with([
                     store_key("verbose"),
                     names(&["v", "verbose"]),
                     desc("Make the operation more talkative"),
                 ]),
-                cliargs::OptCfg::with(&[
+                cliargs::OptCfg::with([
                     store_key("version"),
                     names(&["V", "version"]),
                     desc("Show version number and quit"),

--- a/tests/parse_with_test.rs
+++ b/tests/parse_with_test.rs
@@ -6,10 +6,12 @@ mod tests_of_parse_with {
 
     #[test]
     fn it_should_parse_command_line_arguments_with_option_configurations() {
+        let params1 = vec![store_key("fooBar"), names(&["foo-bar", "f"])];
+
         let opt_cfgs = vec![
-            OptCfg::with(&[store_key("fooBar"), names(&["foo-bar", "f"])]),
-            OptCfg::with(&[names(&["baz", "b"]), has_arg(true)]),
-            OptCfg::with(&[
+            OptCfg::with(params1),
+            OptCfg::with([names(&["baz", "b"]), has_arg(true)]),
+            OptCfg::with([
                 names(&["qux", "q"]),
                 has_arg(true),
                 is_array(true),
@@ -85,17 +87,17 @@ mod tests_of_parse_until_sub_cmd_with {
     #[test]
     fn it_should_parse_command_line_arguments_containing_subcommand() {
         let opt_cfgs1 = vec![
-            OptCfg::with(&[
+            OptCfg::with([
                 store_key("fooBar"),
                 names(&["foo-bar", "f"]),
                 has_arg(true),
                 validator(validate_number::<u32>),
             ]),
-            OptCfg::with(&[names(&["v"])]),
+            OptCfg::with([names(&["v"])]),
         ];
         let opt_cfgs2 = vec![
-            OptCfg::with(&[names(&["q"]), has_arg(true)]),
-            OptCfg::with(&[names(&["qux"])]),
+            OptCfg::with([names(&["q"]), has_arg(true)]),
+            OptCfg::with([names(&["qux"])]),
         ];
 
         let mut cmd = Cmd::with_strings([
@@ -151,9 +153,9 @@ mod tests_of_errors {
     #[test]
     fn it_should_parse_but_fail_if_the_option_does_not_match_configuration() {
         let opt_cfgs = vec![
-            OptCfg::with(&[store_key("fooBar"), names(&["foo-bar", "f"])]),
-            OptCfg::with(&[names(&["baz", "b"]), has_arg(true)]),
-            OptCfg::with(&[
+            OptCfg::with([store_key("fooBar"), names(&["foo-bar", "f"])]),
+            OptCfg::with([names(&["baz", "b"]), has_arg(true)]),
+            OptCfg::with([
                 names(&["qux", "q"]),
                 has_arg(true),
                 is_array(true),
@@ -229,9 +231,9 @@ mod tests_of_errors {
     #[test]
     fn it_should_parse_but_fail_if_the_option_argument_is_invalid() {
         let opt_cfgs = vec![
-            OptCfg::with(&[store_key("fooBar"), names(&["foo-bar", "f"])]),
-            OptCfg::with(&[names(&["baz", "b"]), has_arg(true)]),
-            OptCfg::with(&[
+            OptCfg::with([store_key("fooBar"), names(&["foo-bar", "f"])]),
+            OptCfg::with([names(&["baz", "b"]), has_arg(true)]),
+            OptCfg::with([
                 names(&["qux", "q"]),
                 has_arg(true),
                 is_array(true),


### PR DESCRIPTION
This PR changes the parameter type of `OptCfg::with` from `&[OptCfgParam]` to `impl IntoIterator<Item = OptCfgParam>`  because it make enable to remove `&` before `[]` like `OptCfg::with([store_key("foo")])` instead of `OptCfg::with(&[store_key("foo")])`.