### PR TITLE
fix: remade Cmd#sub_cmd not to retrieve a base name of a path-like sub command

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -501,11 +501,25 @@ impl<'b, 'a> Cmd<'a> {
     }
 
     fn sub_cmd(&'a self, from_index: usize) -> Cmd<'b> {
-        Cmd::with_strings(
-            self._leaked_strs[from_index..(self._num_of_args)]
-                .into_iter()
-                .map(|s| s.to_string()),
-        )
+        let arg_iter = self._leaked_strs[from_index..(self._num_of_args)].into_iter();
+        let (size, _) = arg_iter.size_hint();
+        let mut _leaked_strs = Vec::with_capacity(size);
+
+        for arg in arg_iter {
+            let str: &'b str = arg.to_string().leak();
+            _leaked_strs.push(str);
+        }
+
+        let _num_of_args = _leaked_strs.len();
+
+        Cmd {
+            name: &_leaked_strs[0],
+            args: Vec::new(),
+            opts: HashMap::new(),
+            cfgs: Vec::new(),
+            _leaked_strs,
+            _num_of_args,
+        }
     }
 
     /// Returns the command name.

--- a/src/parse/parse.rs
+++ b/src/parse/parse.rs
@@ -799,4 +799,28 @@ mod tests_of_parse_until_sub_cmd {
         assert_eq!(cmd.has_opt("f#o"), false);
         assert_eq!(cmd.opt_arg("f#o"), None);
     }
+
+    #[test]
+    fn test_if_sub_command_is_like_path() { // for the fix of issue #39
+        let ui_args = vec![
+            "/path/to/app".to_string(),
+            "--foo-bar".to_string(),
+            "path/to/bar".to_string(),
+            "--baz".to_string(),
+            "qux".to_string()
+        ];
+        let mut cmd = Cmd::with_strings(ui_args);
+
+        if let Some(mut sub_cmd) = cmd.parse_until_sub_cmd().unwrap() {
+          sub_cmd.parse().unwrap();
+
+          assert_eq!(cmd.name(), "app");
+          assert_eq!(cmd.args(), &[] as &[&str]);
+          assert_eq!(cmd.has_opt("foo-bar"), true);
+
+          assert_eq!(sub_cmd.name(), "path/to/bar");
+          assert_eq!(sub_cmd.args(), &["qux"]);
+          assert_eq!(sub_cmd.has_opt("baz"), true);
+        }
+    }
 }


### PR DESCRIPTION
Resolves #39