### PR TITLE
update!: changed OptCfg::make_cfgs_for to make_opt_cfgs_for

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -326,6 +326,7 @@ pub use help::HelpIter;
 pub use opt_cfg::validators;
 
 mod parse;
+pub use parse::make_opt_cfgs_for;
 pub use parse::OptStore;
 
 extern crate cliargs_derive;

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -6,6 +6,7 @@ mod parse;
 mod parse_with;
 
 mod parse_for;
+pub use parse_for::make_opt_cfgs_for;
 pub use parse_for::OptStore;
 
 use crate::errors::InvalidOption;

--- a/src/parse/parse.rs
+++ b/src/parse/parse.rs
@@ -801,26 +801,27 @@ mod tests_of_parse_until_sub_cmd {
     }
 
     #[test]
-    fn test_if_sub_command_is_like_path() { // for the fix of issue #39
+    fn test_if_sub_command_is_like_path() {
+        // for the fix of issue #39
         let ui_args = vec![
             "/path/to/app".to_string(),
             "--foo-bar".to_string(),
             "path/to/bar".to_string(),
             "--baz".to_string(),
-            "qux".to_string()
+            "qux".to_string(),
         ];
         let mut cmd = Cmd::with_strings(ui_args);
 
         if let Some(mut sub_cmd) = cmd.parse_until_sub_cmd().unwrap() {
-          sub_cmd.parse().unwrap();
+            sub_cmd.parse().unwrap();
 
-          assert_eq!(cmd.name(), "app");
-          assert_eq!(cmd.args(), &[] as &[&str]);
-          assert_eq!(cmd.has_opt("foo-bar"), true);
+            assert_eq!(cmd.name(), "app");
+            assert_eq!(cmd.args(), &[] as &[&str]);
+            assert_eq!(cmd.has_opt("foo-bar"), true);
 
-          assert_eq!(sub_cmd.name(), "path/to/bar");
-          assert_eq!(sub_cmd.args(), &["qux"]);
-          assert_eq!(sub_cmd.has_opt("baz"), true);
+            assert_eq!(sub_cmd.name(), "path/to/bar");
+            assert_eq!(sub_cmd.args(), &["qux"]);
+            assert_eq!(sub_cmd.has_opt("baz"), true);
         }
     }
 }

--- a/src/parse/parse_for.rs
+++ b/src/parse/parse_for.rs
@@ -19,25 +19,23 @@ pub trait OptStore {
     fn set_field_values(&mut self, m: &HashMap<&str, Vec<&str>>) -> Result<(), InvalidOption>;
 }
 
-impl OptCfg {
-    /// Makes a vector of [OptCfg] struct instances from the field definitions and `opt` field
-    /// attributes of the struct instnace of which type is `T`.
-    ///
-    /// One [OptCfg] struct instance is made for each field.
-    /// The field name is set to `store_key`.
-    /// If the field's data type is `bool`, `has_arg` is set to `false`, otherwise, it is set to
-    /// `true`.
-    /// If the field is a vector type, `is_array` is set to `true`; otherwise, it is set to
-    /// `false`.
-    ///
-    /// Additionally, `names`, `defaults`, `desc`, and `arg_in_help` are set with extracted from
-    /// the `opt` attribute attached to the field.
-    ///
-    /// For `validator`, if the field's data type is numeric, it is set to the `validate_number`
-    /// function pointer corresponding to the data type.
-    pub fn make_cfgs_for<T: OptStore>(opt_store: &mut T) -> Vec<OptCfg> {
-        opt_store.make_opt_cfgs()
-    }
+/// Makes a vector of [OptCfg] struct instances from the field definitions and `opt` field
+/// attributes of the struct instnace of which type is `T`.
+///
+/// One [OptCfg] struct instance is made for each field.
+/// The field name is set to `store_key`.
+/// If the field's data type is `bool`, `has_arg` is set to `false`, otherwise, it is set to
+/// `true`.
+/// If the field is a vector type, `is_array` is set to `true`; otherwise, it is set to
+/// `false`.
+///
+/// Additionally, `names`, `defaults`, `desc`, and `arg_in_help` are set with extracted from
+/// the `opt` attribute attached to the field.
+///
+/// For `validator`, if the field's data type is numeric, it is set to the `validate_number`
+/// function pointer corresponding to the data type.
+pub fn make_opt_cfgs_for<T: OptStore>(opt_store: &mut T) -> Vec<OptCfg> {
+    opt_store.make_opt_cfgs()
 }
 
 impl<'b> Cmd<'_> {
@@ -180,7 +178,7 @@ impl<'b> Cmd<'_> {
 }
 
 #[cfg(test)]
-mod tests_of_make_cfgs_for {
+mod tests_of_make_opt_cfgs_for {
     use super::*;
     use crate as cliargs;
     extern crate cliargs_derive;
@@ -304,7 +302,7 @@ mod tests_of_make_cfgs_for {
         #[test]
         fn test_make_opt_cfgs_for_opt_store() {
             let mut store = NoAttrOptions::with_defaults();
-            let cfgs = cliargs::OptCfg::make_cfgs_for(&mut store);
+            let cfgs = cliargs::make_opt_cfgs_for(&mut store);
             assert_eq!(cfgs.len(), 40);
 
             let cfg = &cfgs[0];
@@ -1084,7 +1082,7 @@ mod tests_of_make_cfgs_for {
         #[test]
         fn test_make_opt_cfgs_for_store() {
             let mut store = WithAttrOptions::with_defaults();
-            let cfgs = cliargs::OptCfg::make_cfgs_for(&mut store);
+            let cfgs = cliargs::make_opt_cfgs_for(&mut store);
             assert_eq!(cfgs.len(), 40);
 
             let cfg = &cfgs[0];
@@ -1501,7 +1499,7 @@ mod tests_of_make_cfgs_for {
                 empty_str: Vec<String>,
             }
             let mut store = MyOptions::with_defaults();
-            let cfgs = cliargs::OptCfg::make_cfgs_for(&mut store);
+            let cfgs = cliargs::make_opt_cfgs_for(&mut store);
             assert_eq!(cfgs.len(), 4);
             assert_eq!(cfgs[0].store_key, "empty".to_string());
             assert_eq!(cfgs[0].defaults, Some(Vec::<String>::new()));

--- a/tests/parse_for_test.rs
+++ b/tests/parse_for_test.rs
@@ -9,11 +9,11 @@ mod tests_of_parse_for {
     }
 
     #[test]
-    fn make_cfgs_for_my_options() {
+    fn make_opt_cfgs_for_my_options() {
         let mut my_options = MyOptions::with_defaults();
         assert_eq!(my_options.foo_bar, false);
 
-        let cfgs = cliargs::OptCfg::make_cfgs_for(&mut my_options);
+        let cfgs = cliargs::make_opt_cfgs_for(&mut my_options);
         assert_eq!(cfgs.len(), 1);
 
         let cfg = &cfgs[0];


### PR DESCRIPTION
This PR changes an API path and name of `cliargs::OptCfg::make_cfgs_for` to `cliargs::make_opt_cfgs_for`.

This change is to align the name with `cliargs`(golang) and `cliargs-java`.