### PR TITLE
0.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cliargs"
-version = "0.5.2"
+version = "0.6.0"
 authors = ["Takayuki Sato <sttk.xslet@gmail.com>"]
 edition = "2021"
 rust-version = "1.74.1"

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ In `Cargo.toml`, write this crate as a dependency.
 
 ```toml
 [dependencies]
-cliargs = "0.5.2"
+cliargs = "0.6.0"
 ```
 
 ## Usage
@@ -301,7 +301,7 @@ See the file LICENSE in this distribution for more details.
 
 
 [repo-url]: https://github.com/sttk/cliargs-rust
-[crateio-img]: https://img.shields.io/badge/crate.io-ver.0.5.2-fc8d62?logo=rust
+[crateio-img]: https://img.shields.io/badge/crate.io-ver.0.6.0-fc8d62?logo=rust
 [crateio-url]: https://crates.io/crates/cliargs
 [docrs-img]: https://img.shields.io/badge/doc.rs-cliargs-66c2a5?logo=docs.rs
 [docrs-url]: https://docs.rs/cliargs

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! cliargs = "0.5.2"
+//! cliargs = "0.6.0"
 //! ```
 //!
 //! ## Usage


### PR DESCRIPTION
> This is the release again of #54, because it had been released as fix release though it contained a breaking change.

- [x] Update the version number in `Cargo.toml`
- [x] Update the texts about version number in `README.md`
- [x] Update the texts about version number of document comments in `src/lib.rs`
- [-] Update the version number in `cliargs_derive/Cargo.toml` 
- [-] Update the texts about version number in `cliargs_derive/README.md`

